### PR TITLE
[CXP-230] Fix broken post-delete user verification

### DIFF
--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -10,8 +10,6 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-zoom/pkg/zoom"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type userResourceType struct {
@@ -196,14 +194,8 @@ func (u *userResourceType) Delete(ctx context.Context, principal *v2.ResourceId)
 
 	err := u.client.DeleteUser(ctx, userID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("baton-zoom: failed to delete user %s: %w", userID, err)
 	}
-
-	_, resp, err := u.client.GetUser(ctx, userID)
-	if err == nil || status.Code(err) != codes.NotFound {
-		return nil, fmt.Errorf("error deleting user. User %s still exists", userID)
-	}
-	defer resp.Body.Close()
 
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

- Removes the broken post-delete verification in `Delete()` that always reported "User still exists" even on successful deletion
- The verification used `status.Code(err)` to check for gRPC `codes.NotFound`, but the zoom client's `doRequest` returns plain `fmt.Errorf` errors — so `status.Code()` always returned `codes.Unknown`, causing the check to always fail
- This also fixes a latent nil pointer dereference on `resp.Body.Close()` since `GetUser` returns `nil` for `resp` on error

Supersedes #17 which attempted to fix this with a `time.Sleep` delay, but the sleep doesn't help because the verification logic itself is broken regardless of timing.

## Test plan

- [ ] Run a user deletion deprovision against Zoom and verify it succeeds without error
- [ ] Confirm no regression on user creation provisioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for user deletion failures with clearer context.

* **Refactor**
  * Simplified user deletion logic by removing redundant validation calls and streamlining error handling flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->