### PR TITLE
[CXH-1571] - Add License management - Zoom Connector

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,10 +8,10 @@ jobs:
       BATON_ACCOUNT_ID: ${{ secrets.BATON_ACCOUNT_ID }}
       BATON_ZOOM_CLIENT_ID: ${{ secrets.BATON_ZOOM_CLIENT_ID }}
       BATON_ZOOM_CLIENT_SECRET: ${{ secrets.BATON_ZOOM_CLIENT_SECRET }}
-      CONNECTOR_GRANT: 'group:zjg1idFWQt25Ohhr7752Wg:member:user:7czGQEusRh2IasXfsdDh_Q'
-      CONNECTOR_ENTITLEMENT: 'group:zjg1idFWQt25Ohhr7752Wg:member'
-      CONNECTOR_PRINCIPAL: '7czGQEusRh2IasXfsdDh_Q'
-      CONNECTOR_PRINCIPAL_TYPE: 'user'
+      CONNECTOR_PRINCIPAL: ${{ vars.TEST_PRINCIPAL }}
+      CONNECTOR_PRINCIPAL_TYPE: ${{ vars.TEST_PRINCIPAL_TYPE }}
+      CONNECTOR_ENTITLEMENT: group:${{ vars.TEST_GROUP_ID }}:member
+      CONNECTOR_GRANT: group:${{ vars.TEST_GROUP_ID }}:member:user:${{ vars.TEST_PRINCIPAL }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # baton-zoom
-`baton-zoom` is a connector for Zoom built using the [Baton SDK](https://github.com/conductorone/baton-sdk). It communicates with the Zoom API to sync data about users, groups and roles.
+
+`baton-zoom` is a connector for Zoom built using the [Baton SDK](https://github.com/conductorone/baton-sdk). It communicates with the Zoom API to sync data about users, groups, roles and license tiers.
 
 Check out [Baton](https://github.com/conductorone/baton) to learn more the project in general.
 
@@ -9,7 +10,9 @@ Check out [Baton](https://github.com/conductorone/baton) to learn more the proje
 
 1. Zoom [server to server app](https://developers.zoom.us/docs/internal-apps/create/) created in [marketplace](https://marketplace.zoom.us/)
 2. Scopes for syncing only(no provisioning):
+
 - contact_group:read:list_groups:admin
+- contact_group:read:list_members:admin
 - group:read:list_groups:admin
 - group:read:list_members:admin
 - group:read:administrator:admin
@@ -17,17 +20,36 @@ Check out [Baton](https://github.com/conductorone/baton) to learn more the proje
 - role:read:list_members:admin
 - user:read:user:admin
 - user:read:list_users:admin
+- billing:read:plan_usage:admin (optional, used to surface purchased vs. consumed Licensed seat counts)
 
 Scopes for provisioning (grant/revoke)
+
 - role:write:member:admin
 - role:delete:member:admin
 - group:write:member:admin
 - group:delete:member:admin
-- user:write:user:admin
+- group:write:administrator:admin
+- group:delete:administrator:admin
+- user:write:user:admin (create users)
+- user:update:user:admin (assign/revoke license tier via PATCH /v2/users/{userId})
 - user:delete:user:admin
 
 3. Pro or higher [plan](https://zoom.us/pricing)
 4. Activate the App for Account ID, Client ID and Client Secret needed to use the API
+
+## License tiers
+
+The connector models Zoom's three user license tiers as a `license` resource type:
+
+| Tier     | Zoom `type` | Consumes a seat?          |
+| -------- | ----------- | ------------------------- |
+| Basic    | `1`         | No                        |
+| Licensed | `2`         | Yes                       |
+| On-Prem  | `3`         | No (managed off-platform) |
+
+Granting a license PATCHes the user's `type` field to the target tier. Revoking a license is a downgrade to Basic — Zoom has no "no license" state, and Basic is the floor. Revoking a Basic grant is a no-op since Basic does not occupy a seat.
+
+When the `billing:read:plan_usage:admin` scope is granted, the Licensed resource is decorated with `purchased_seats` and `consumed_seats` (from `GET /v2/accounts/me/plans/usage` → `plan_base.hosts` / `plan_base.usage`). Without the scope, sync still succeeds — only the seat counts are omitted.
 
 ## brew
 
@@ -57,11 +79,13 @@ baton resources
 # Data Model
 
 `baton-zoom` pulls down information about the following Zoom resources:
+
 - Users
 - Invites (pending users)
 - Groups
 - Contact Groups
 - Roles
+- Licenses (Basic / Licensed / On-Prem)
 
 # Contributing, Support, and Issues
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Scopes for provisioning (grant/revoke)
 
 The connector models Zoom's three user license tiers as a `license` resource type:
 
-| Tier     | Zoom `type` | Consumes a seat?          |
-| -------- | ----------- | ------------------------- |
-| Basic    | `1`         | No                        |
-| Licensed | `2`         | Yes                       |
-| On-Prem  | `3`         | No (managed off-platform) |
+| Tier       | Zoom `type` | Consumes a seat?         |
+| ---------- | ----------- | ------------------------ |
+| Basic      | `1`         | No                       |
+| Licensed   | `2`         | Yes                      |
+| Unassigned | `4`         | No (no meetings license) |
 
 Granting a license PATCHes the user's `type` field to the target tier. Revoking a license is a downgrade to Basic — Zoom has no "no license" state, and Basic is the floor. Revoking a Basic grant is a no-op since Basic does not occupy a seat.
 
@@ -85,7 +85,7 @@ baton resources
 - Groups
 - Contact Groups
 - Roles
-- Licenses (Basic / Licensed / On-Prem)
+- Licenses (Basic / Licensed / Unassigned)
 
 # Contributing, Support, and Issues
 

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -158,6 +158,9 @@
                 "permission": "billing:read:plan_usage:admin"
               }
             ]
+          },
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipGrants"
           }
         ]
       },
@@ -256,7 +259,7 @@
             ]
           },
           {
-            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlements"
           }
         ]
       },

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -136,6 +136,54 @@
     },
     {
       "resourceType": {
+        "id": "license",
+        "displayName": "License",
+        "traits": [
+          "TRAIT_LICENSE_PROFILE"
+        ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
+            "permissions": [
+              {
+                "permission": "user:read:list_users:admin"
+              },
+              {
+                "permission": "user:read:user:admin"
+              },
+              {
+                "permission": "user:update:user:admin"
+              },
+              {
+                "permission": "billing:read:plan_usage:admin"
+              }
+            ]
+          }
+        ]
+      },
+      "capabilities": [
+        "CAPABILITY_SYNC",
+        "CAPABILITY_PROVISION"
+      ],
+      "permissions": {
+        "permissions": [
+          {
+            "permission": "user:read:list_users:admin"
+          },
+          {
+            "permission": "user:read:user:admin"
+          },
+          {
+            "permission": "user:update:user:admin"
+          },
+          {
+            "permission": "billing:read:plan_usage:admin"
+          }
+        ]
+      }
+    },
+    {
+      "resourceType": {
         "id": "role",
         "displayName": "Role",
         "traits": [

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -8,51 +8,50 @@ sidebarTitle: Zoom
 
 ## Availability
 
-This connector works with Zoom on the Pro, Business, Business Plus, or Enterprise plan. The Zoom Basic plan is not supported. 
+This connector works with Zoom on the Pro, Business, Business Plus, or Enterprise plan. The Zoom Basic plan is not supported.
 
 ## Capabilities
 
-| Resource     | Sync | Provision |
-| ------------ | ---- | --------- |
-| Accounts     | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>   | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>        |
-| Groups       | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>   | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>  |
-| Roles        | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>   | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>  |
-| Contact groups | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |     |
-| Invites      | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>   |     |
+| Resource       | Sync                                                          | Provision                                                     |
+| -------------- | ------------------------------------------------------------- | ------------------------------------------------------------- |
+| Accounts       | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Groups         | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Roles          | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Licenses       | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Contact groups | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |                                                               |
+| Invites        | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |                                                               |
 
 The Zoom connector supports [automatic account provisioning](/product/admin/account-provisioning).
 
 The Zoom connector supports account deprovisioning (user deletion).
 
-## Gather Zoom credentials 
+## Gather Zoom credentials
 
-Configuring the connector requires you to pass in credentials generated in Zoom. Gather these credentials before you move on. 
+Configuring the connector requires you to pass in credentials generated in Zoom. Gather these credentials before you move on.
 
 <Warning>
-A user with **Account Owner** status in Zoom must perform this task.
+  A user with **Account Owner** status in Zoom must perform this task.
 </Warning>
 
 ### Create a Zoom OAuth app
 
 <Steps>
-<Step>
-Navigate to the [Zoom App Marketplace](https://marketplace.zoom.us/). 
-</Step>
-<Step>
-Click **Develop** and select **Build App**. 
-</Step>
-<Step>
-Locate the **Server-to-Server OAuth** option and click **Create**. 
-</Step>
-<Step>
-Give your app a name, such as "C1" and click **Create**. 
-</Step>
-<Step>
-A page for the newly created app opens. Copy and save the Account ID, Client ID, and Client secret shown on this page.  
-</Step>
+  <Step>
+    Navigate to the [Zoom App Marketplace](https://marketplace.zoom.us/).
+  </Step>
+  <Step>Click **Develop** and select **Build App**.</Step>
+  <Step>
+    Locate the **Server-to-Server OAuth** option and click **Create**.
+  </Step>
+  <Step>Give your app a name, such as "C1" and click **Create**.</Step>
+  <Step>
+    A page for the newly created app opens. Copy and save the Account ID, Client
+    ID, and Client secret shown on this page.
+  </Step>
 </Steps>
 
 ### Configure and activate the OAuth app
+
 <Steps>
 <Step>
 From the **App Credentials** page, click **Continue**. 
@@ -64,28 +63,31 @@ On the **Basic information** page, fill out the form and click **Continue**.
 On the **Feature** page, do not make any changes. Click **Continue**. 
 </Step>
 <Step>
-On the **Scopes** page, click **+ Add Scopes**. Give the app the following set of scopes: 
+On the **Scopes** page, click **+ Add Scopes**. Give the app the following set of scopes:
 
-   - contact_group:read:list_groups:admin
-   - contact_group:read:list_members:admin
-   - group:read:list_groups:admin
-   - group:read:list_members:admin
-   - group:read:administrator:admin
-   - role:read:list_roles:admin
-   - role:read:list_members:admin
-   - user:read:user:admin
-   - user:read:list_users:admin
+- contact_group:read:list_groups:admin
+- contact_group:read:list_members:admin
+- group:read:list_groups:admin
+- group:read:list_members:admin
+- group:read:administrator:admin
+- role:read:list_roles:admin
+- role:read:list_members:admin
+- user:read:user:admin
+- user:read:list_users:admin
+- `billing:read:plan_usage:admin` (optional — required only if you want C1 to surface purchased vs. consumed Licensed seat counts)
 
-   If you want to use C1 to provision and deprovision Zoom permissions, add these scopes as well:
+If you want to use C1 to provision and deprovision Zoom permissions, add these scopes as well:
 
-   - role:write:member:admin
-   - role:delete:member:admin
-   - group:write:member:admin
-   - group:delete:member:admin
-   - user:write:user:admin
-   - user:delete:user:admin
-   - group:write:administrator:admin
-   - group:delete:administrator:admin
+- role:write:member:admin
+- role:delete:member:admin
+- group:write:member:admin
+- group:delete:member:admin
+- user:write:user:admin _(create users)_
+- user:update:user:admin _(required to assign/revoke a license tier)_
+- user:delete:user:admin
+- group:write:administrator:admin
+- group:delete:administrator:admin
+
 </Step>
 <Step>
 Click **Done**. Review the list of scopes and click **Continue**. 
@@ -103,6 +105,7 @@ To complete this task, you'll need:
 
 - The **Connector Administrator** or **Super Administrator** role in C1
 - Access to the set of Zoom credentials generated by following the instructions above
+
 </Warning>
 
 <Tabs>
@@ -118,18 +121,20 @@ In C1, navigate to **Integrations** > **Connectors** and click **Add connector**
 Search for **Zoom** and click **Add**. 
 </Step>
 <Step>
-Choose how to set up the new Zoom connector: 
+Choose how to set up the new Zoom connector:
 
-   * Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with C1)
+- Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with C1)
 
-   * Add the connector to a managed app (select from the list of existing managed apps)
+- Add the connector to a managed app (select from the list of existing managed apps)
 
-   * Create a new managed app
+- Create a new managed app
+
 </Step>
 <Step>
-Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of C1 users. Setting multiple owners is allowed. 
+Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of C1 users. Setting multiple owners is allowed.
 
-   If you choose someone else, C1 will notify the new connector owner by email that their help is needed to complete the setup process.
+If you choose someone else, C1 will notify the new connector owner by email that their help is needed to complete the setup process.
+
 </Step>
 <Step>
 Click **Next**.
@@ -163,7 +168,7 @@ When running in service mode on Kubernetes, a self-hosted connector maintains an
 
 ### Resources
 
-* [GitHub repository](https://github.com/conductorone/baton-zoom): Access the source code, report issues, or contribute to the project.
+- [GitHub repository](https://github.com/conductorone/baton-zoom): Access the source code, report issues, or contribute to the project.
 
 ### Step 1: Set up a new Zoom connector
 
@@ -175,18 +180,20 @@ In C1, navigate to **Integrations** > **Connectors** > **Add connector**.
 Search for **Baton** and click **Add**.
 </Step>
 <Step>
-Choose how to set up the new Zoom connector: 
+Choose how to set up the new Zoom connector:
 
-   * Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with C1)
+- Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with C1)
 
-   * Add the connector to a managed app (select from the list of existing managed apps)
+- Add the connector to a managed app (select from the list of existing managed apps)
 
-   * Create a new managed app
+- Create a new managed app
+
 </Step>
 <Step>
-Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of C1 users. Setting multiple owners is allowed. 
+Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of C1 users. Setting multiple owners is allowed.
 
-   If you choose someone else, C1 will notify the new connector owner by email that their help is needed to complete the setup process.
+If you choose someone else, C1 will notify the new connector owner by email that their help is needed to complete the setup process.
+
 </Step>
 <Step>
 Click **Next**.
@@ -195,9 +202,10 @@ Click **Next**.
 In the **Settings** area of the page, click **Edit**.
 </Step>
 <Step>
-Click **Rotate** to generate a new Client ID and Secret. 
+Click **Rotate** to generate a new Client ID and Secret.
 
-   Carefully copy and save these credentials. We'll use them in Step 2. 
+Carefully copy and save these credentials. We'll use them in Step 2.
+
 </Step>
 </Steps>
 ### Step 2: Create Kubernetes configuration files
@@ -217,7 +225,7 @@ stringData:
   # C1 credentials
   BATON_CLIENT_ID: <C1 client ID>
   BATON_CLIENT_SECRET: <C1 client secret>
-  
+
   # Zoom credentials
   BATON_ACCOUNT_ID: <Zoom app account ID>
   BATON_ZOOM_CLIENT_ID: <Zoom client ID>
@@ -254,26 +262,30 @@ spec:
         baton-app: zoom
     spec:
       containers:
-      - name: baton-zoom
-        image: public.ecr.aws/conductorone/baton-zoom:latest
-        imagePullPolicy: IfNotPresent
-        env:
-        - name: BATON_HOST_ID
-          value: baton-zoom
-        envFrom:
-        - secretRef:
-            name: baton-zoom-secrets
+        - name: baton-zoom
+          image: public.ecr.aws/conductorone/baton-zoom:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: BATON_HOST_ID
+              value: baton-zoom
+          envFrom:
+            - secretRef:
+                name: baton-zoom-secrets
 ```
 
 ### Step 3: Deploy the connector
 
 <Steps>
-<Step>
-Create a namespace in which to run C1 connectors (if desired), then apply the secret config and deployment config files. 
-</Step>
-<Step>
-Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Zoom connector to. Zoom data should be found on the **Entitlements** and **Accounts** tabs.
-</Step>
+  <Step>
+    Create a namespace in which to run C1 connectors (if desired), then apply
+    the secret config and deployment config files.
+  </Step>
+  <Step>
+    Check that the connector data uploaded correctly. In C1, click **Apps**. On
+    the **Managed apps** tab, locate and click the name of the application you
+    added the Zoom connector to. Zoom data should be found on the
+    **Entitlements** and **Accounts** tabs.
+  </Step>
 </Steps>
 
 **Done.** Your Zoom connector is now pulling access data into C1.

--- a/docs/doc-info.md
+++ b/docs/doc-info.md
@@ -1,0 +1,144 @@
+# `baton-zoom` doc-info
+
+While developing the connector, please fill out this form. This information is needed to write docs and to help other users set up the connector.
+
+## Connector capabilities
+
+### 1. What resources does the connector sync?
+
+| Resource           | Trait                   | Notes                                                                                                                                                                                                                                        |
+| ------------------ | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Users**          | `TRAIT_USER`            | Active users; inactive users included when `--sync-inactive-users` is set.                                                                                                                                                                   |
+| **Invites**        | `TRAIT_USER`            | Pending users (Zoom users with `status=pending`). No native ID yet — synced as a separate type.                                                                                                                                              |
+| **Groups**         | `TRAIT_GROUP`           | Zoom Groups with both members and admins as principals.                                                                                                                                                                                      |
+| **Contact Groups** | `TRAIT_GROUP`           | Read-only. Membership includes both users and nested user-groups.                                                                                                                                                                            |
+| **Roles**          | `TRAIT_ROLE`            | A user can hold one role at a time; emits a `member` entitlement.                                                                                                                                                                            |
+| **Licenses**       | `TRAIT_LICENSE_PROFILE` | Static set of 3 tiers: Basic (`1`), Licensed (`2`), On-Prem (`3`). Each emits an `assigned` entitlement. Purchased / consumed seat counts are populated for the **Licensed** tier when the `billing:read:plan_usage:admin` scope is granted. |
+
+### 2. Can the connector provision any resources? If so, which ones?
+
+Yes:
+
+| Resource     | Operations                                         | API surface                                                                                             |
+| ------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Users**    | **Create account**, **Delete user**                | `POST /v2/users` (action=`create`); `DELETE /v2/users/{userId}`                                         |
+| **Groups**   | Add/Remove members, Add/Remove admins              | `POST /v2/groups/{groupId}/members`; `DELETE /v2/groups/{groupId}/members/{userId}`; same for `/admins` |
+| **Roles**    | Assign/Unassign role to a user                     | `POST /v2/roles/{roleId}/members`; `DELETE /v2/roles/{roleId}/members/{userId}`                         |
+| **Licenses** | Grant (assign a tier), Revoke (downgrade to Basic) | `PATCH /v2/users/{userId}` with body `{"type": N}`                                                      |
+
+**License Revoke semantics:** Zoom has no "no license" state — Basic is the floor and does not consume a seat. Revoking the **Licensed** or **On-Prem** tier downgrades the user back to Basic, freeing the seat. Revoking a **Basic** grant is a logical no-op (returns `GrantAlreadyRevoked` without an API call).
+
+Contact Groups are intentionally **read-only** (no membership write endpoints are exposed by Zoom's public API).
+
+## Connector credentials
+
+### 1. What credentials or information are needed to set up the connector?
+
+The connector uses **Server-to-Server OAuth (S2S OAuth)**. The user must provide three values:
+
+| Field         | Env var                    | Required |
+| ------------- | -------------------------- | -------- |
+| Account ID    | `BATON_ACCOUNT_ID`         | Yes      |
+| Client ID     | `BATON_ZOOM_CLIENT_ID`     | Yes      |
+| Client Secret | `BATON_ZOOM_CLIENT_SECRET` | Yes      |
+
+The connector exchanges these for a short-lived bearer token at `POST https://zoom.us/oauth/token?grant_type=account_credentials&account_id=<account_id>` using HTTP Basic auth (`client_id:client_secret`). The token expires after ~1 hour and is requested at startup.
+
+### 2. For each item above
+
+#### How does a user create or look up that credential?
+
+All three credentials originate from the same Server-to-Server OAuth app in the [Zoom App Marketplace](https://marketplace.zoom.us/).
+
+1. Go to the [Zoom App Marketplace](https://marketplace.zoom.us/) and sign in as a user with **Account Owner** (or Admin with developer privileges) status.
+2. Click **Develop** → **Build App**.
+3. Locate the **Server-to-Server OAuth** card and click **Create**.
+4. Name the app (e.g. "ConductorOne") and click **Create**.
+5. The **App Credentials** page opens. The **Account ID**, **Client ID**, and **Client Secret** are all shown on this page. Copy and save them.
+6. Click **Continue**, fill out **Basic information** (company name, contact, etc.), click **Continue**.
+7. Skip the **Feature** page (no changes needed), click **Continue**.
+8. On the **Scopes** page, click **+ Add Scopes** and add the scopes listed below (Sync, and optionally Provisioning and Billing).
+9. Click **Continue**, then **Activate your app**.
+
+Reference: <https://developers.zoom.us/docs/internal-apps/create/>
+
+#### Does the credential need any specific scopes or permissions? If so, list them here.
+
+Yes. All scopes are **granular admin scopes**. The connector validates each scope only against the resource type that needs it — missing optional scopes degrade individual resource types gracefully (e.g. without `billing:read:plan_usage:admin`, License resources are still synced but seat counts are omitted).
+
+#### Sync-only (read) scopes
+
+Minimum set required for read-only sync of all resource types:
+
+```text
+contact_group:read:list_groups:admin
+contact_group:read:list_members:admin
+group:read:list_groups:admin
+group:read:list_members:admin
+group:read:administrator:admin
+role:read:list_roles:admin
+role:read:list_members:admin
+user:read:user:admin
+user:read:list_users:admin
+```
+
+Optional (recommended) for license seat reporting:
+
+```text
+billing:read:plan_usage:admin
+```
+
+> Without `billing:read:plan_usage:admin`, the `Licenses` resource type still syncs — it just omits the `purchased_seats` / `consumed_seats` fields on the Licensed tier. The connector logs a warning and continues.
+
+#### Provisioning (read + write) scopes
+
+Add **all sync scopes above**, plus:
+
+```text
+user:write:user:admin
+user:update:user:admin
+user:delete:user:admin
+role:write:member:admin
+role:delete:member:admin
+group:write:member:admin
+group:delete:member:admin
+group:write:administrator:admin
+group:delete:administrator:admin
+```
+
+> **Why both `user:write` and `user:update`?** Zoom splits writes into distinct granular scopes: `user:write:user:admin` only authorizes `POST /v2/users` (account creation), and `user:update:user:admin` is required for `PATCH /v2/users/{userId}` (license tier changes). Requesting only `user:write` is a common pitfall — license grant/revoke will fail with Zoom error code `4711: Invalid access token, does not contain scopes`.
+
+Per-resource breakdown of which scope unlocks which operation:
+
+| Resource | Operation                          | Scope                                                                  |
+| -------- | ---------------------------------- | ---------------------------------------------------------------------- |
+| User     | CreateAccount                      | `user:write:user:admin`                                                |
+| User     | Delete                             | `user:delete:user:admin`                                               |
+| Group    | Add/remove member                  | `group:write:member:admin` + `group:delete:member:admin`               |
+| Group    | Add/remove admin                   | `group:write:administrator:admin` + `group:delete:administrator:admin` |
+| Role     | Assign/unassign role               | `role:write:member:admin` + `role:delete:member:admin`                 |
+| License  | Grant / Revoke (PATCH user `type`) | `user:update:user:admin` (distinct from `user:write:user:admin`)       |
+
+#### Difference between sync and provisioning scopes
+
+| Scope group                        | Sync only | Sync + Provision           |
+| ---------------------------------- | --------- | -------------------------- |
+| Read scopes (`*:read:*:admin`)     | Yes       | Yes                        |
+| `billing:read:plan_usage:admin`    | Optional  | Optional                   |
+| `user:write:user:admin`            | No        | Yes                        |
+| `user:update:user:admin`           | No        | Yes (license Grant/Revoke) |
+| `user:delete:user:admin`           | No        | Yes                        |
+| `role:write:member:admin`          | No        | Yes                        |
+| `role:delete:member:admin`         | No        | Yes                        |
+| `group:write:member:admin`         | No        | Yes                        |
+| `group:delete:member:admin`        | No        | Yes                        |
+| `group:write:administrator:admin`  | No        | Yes                        |
+| `group:delete:administrator:admin` | No        | Yes                        |
+
+#### What level of access does the user need to create the credentials?
+
+- **Zoom Account role:** Must be **Account Owner**, or an Admin with developer access enabled by the Account Owner. The S2S OAuth flow plus the admin scopes (`*:admin`) listed above require ownership/admin privileges. A regular Member account cannot create or activate a Server-to-Server OAuth app with these scopes.
+- **Zoom plan:** Requires a paid plan — **Pro, Business, Business Plus, or Enterprise**. The Free (Basic) plan does not support Server-to-Server OAuth apps with admin scopes and does not expose `/accounts/me/plans/usage`.
+- **Marketplace access:** The user must be able to access <https://marketplace.zoom.us/> with their Zoom credentials and reach the **Develop** menu (only owners/admins see it).
+
+After activation, the credentials remain valid until the app is deactivated or its secret is rotated from the **App Credentials** page. Rotation requires the same Account Owner / Admin role.

--- a/docs/doc-info.md
+++ b/docs/doc-info.md
@@ -13,7 +13,7 @@ While developing the connector, please fill out this form. This information is n
 | **Groups**         | `TRAIT_GROUP`           | Zoom Groups with both members and admins as principals.                                                                                                                                                                                      |
 | **Contact Groups** | `TRAIT_GROUP`           | Read-only. Membership includes both users and nested user-groups.                                                                                                                                                                            |
 | **Roles**          | `TRAIT_ROLE`            | A user can hold one role at a time; emits a `member` entitlement.                                                                                                                                                                            |
-| **Licenses**       | `TRAIT_LICENSE_PROFILE` | Static set of 3 tiers: Basic (`1`), Licensed (`2`), On-Prem (`3`). Each emits an `assigned` entitlement. Purchased / consumed seat counts are populated for the **Licensed** tier when the `billing:read:plan_usage:admin` scope is granted. |
+| **Licenses**       | `TRAIT_LICENSE_PROFILE` | Static set of 3 tiers: Basic (`1`), Licensed (`2`), Unassigned (`4`). Each emits an `assigned` entitlement. Purchased / consumed seat counts are populated for the **Licensed** tier when the `billing:read:plan_usage:admin` scope is granted. |
 
 ### 2. Can the connector provision any resources? If so, which ones?
 
@@ -26,7 +26,7 @@ Yes:
 | **Roles**    | Assign/Unassign role to a user                     | `POST /v2/roles/{roleId}/members`; `DELETE /v2/roles/{roleId}/members/{userId}`                         |
 | **Licenses** | Grant (assign a tier), Revoke (downgrade to Basic) | `PATCH /v2/users/{userId}` with body `{"type": N}`                                                      |
 
-**License Revoke semantics:** Zoom has no "no license" state — Basic is the floor and does not consume a seat. Revoking the **Licensed** or **On-Prem** tier downgrades the user back to Basic, freeing the seat. Revoking a **Basic** grant is a logical no-op (returns `GrantAlreadyRevoked` without an API call).
+**License Revoke semantics:** Zoom has no "no license" state — Basic is the floor and does not consume a seat. Revoking the **Licensed** or **Unassigned** tier downgrades the user back to Basic, freeing the seat. Revoking a **Basic** grant is a logical no-op (returns `GrantAlreadyRevoked` without an API call).
 
 Contact Groups are intentionally **read-only** (no membership write endpoints are exposed by Zoom's public API).
 

--- a/docs/postman/README.md
+++ b/docs/postman/README.md
@@ -1,0 +1,91 @@
+# baton-zoom — Postman collection
+
+Postman v2.1 collection + environment to exercise every Zoom REST endpoint that
+the `baton-zoom` connector uses. Useful for:
+
+- Manually validating credentials and scopes before running the connector.
+- Reproducing a sync or provisioning bug against a real Zoom account.
+- Trying out license tier changes (`PATCH /v2/users/{id}`) and watching their
+  effect on seat counts (`GET /v2/accounts/me/plans/usage`) without touching
+  the connector code.
+
+## Files
+
+| File                                  | Purpose                                                                                                                                                               |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `baton-zoom.postman_collection.json`  | All requests, grouped by resource type. Auth is set at the collection level so every request inherits the bearer token.                                               |
+| `baton-zoom.postman_environment.json` | Placeholders for `accountId`, `clientId`, `clientSecret`, `accessToken`, and the IDs (`userId`, `groupId`, `roleId`, `contactGroupId`) used by per-resource requests. |
+
+## Import order
+
+1. **Postman → Import** the collection JSON.
+2. **Postman → Import** the environment JSON.
+3. Activate the **baton-zoom** environment in the top-right environment selector.
+4. Fill the three credential fields in the environment:
+   - `accountId` — your Zoom account ID (from the S2S OAuth app's _App Credentials_ page).
+   - `clientId` — the OAuth app's Client ID.
+   - `clientSecret` — the OAuth app's Client Secret.
+
+## Auth flow
+
+The collection uses **Server-to-Server OAuth** ([Zoom docs](https://developers.zoom.us/docs/internal-apps/s2s-oauth/)):
+
+1. Open **Auth → Get access token** and click _Send_.
+2. The request hits `POST https://zoom.us/oauth/token` with Basic Auth (`clientId:clientSecret`)
+   and `grant_type=account_credentials`.
+3. The response includes the granted `scope` list (logged to the Postman
+   console) and an `access_token`.
+4. A test script stores the token in the environment variable `accessToken`.
+5. Every other request in the collection uses **Bearer `{{accessToken}}`** via
+   collection-level auth, so you can fire any of them after step 1.
+6. Tokens expire after **1 hour**. Re-run _Get access token_ when you start
+   seeing HTTP 401.
+
+## Scope checklist
+
+If a request returns HTTP 401 with `Invalid access token, does not contain scopes`,
+the missing scope is in the error body. The full list this collection exercises:
+
+| Folder         | Granular scopes                                                                                                                                                                                                                   |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Users          | `user:read:list_users:admin`, `user:read:user:admin`, `user:write:user:admin`, `user:delete:user:admin`                                                                                                                           |
+| License tiers  | `user:read:user:admin`, **`user:update:user:admin`**, `billing:read:plan_usage:admin`                                                                                                                                             |
+| Groups         | `group:read:list_groups:admin`, `group:read:list_members:admin`, `group:read:administrator:admin`, `group:write:member:admin`, `group:delete:member:admin`, `group:write:administrator:admin`, `group:delete:administrator:admin` |
+| Roles          | `role:read:list_roles:admin`, `role:read:list_members:admin`, `role:write:member:admin`, `role:delete:member:admin`                                                                                                               |
+| Contact groups | `contact_group:read:list_groups:admin`, `contact_group:read:list_members:admin`                                                                                                                                                   |
+| Invites        | `user:read:list_users:admin`                                                                                                                                                                                                      |
+
+> **Important — the `user:write:user:admin` vs `user:update:user:admin` gotcha**
+>
+> Zoom split the legacy `user:write:admin` classic scope into three distinct
+> granular scopes. `user:write:user:admin` only authorizes `POST /v2/users`
+> (create). `PATCH /v2/users/{id}` — the call the connector uses for license
+> tier changes — requires the separate **`user:update:user:admin`** scope, and
+> fails with Zoom error code 4711 otherwise. Don't assume the "write" scope
+> covers updates.
+
+## Folder → connector mapping
+
+| Collection folder | Connector resource type    | Connector files                 |
+| ----------------- | -------------------------- | ------------------------------- |
+| Users             | `user`                     | `pkg/connector/user.go`         |
+| License tiers     | `license` (NEW — CXH-1571) | `pkg/connector/license.go`      |
+| Groups            | `group`                    | `pkg/connector/group.go`        |
+| Roles             | `role`                     | `pkg/connector/role.go`         |
+| Contact groups    | `contactGroup`             | `pkg/connector/contactGroup.go` |
+| Invites           | `invite`                   | `pkg/connector/invite.go`       |
+
+## Reproducing the license roundtrip end-to-end
+
+This sequence mirrors the CI workflow's license job:
+
+1. **Auth → Get access token** (token cached in env).
+2. **License tiers → Get plan usage (seat counts)** — note `plan_base.usage`.
+3. Set `userId` in the environment to a Basic test user's ID.
+4. **License tiers → Grant Licensed tier (PATCH type=2)** — should return 204.
+5. **License tiers → Get plan usage** again — `usage` should be +1.
+6. **License tiers → Revoke / downgrade to Basic (PATCH type=1)** — should return 204.
+7. **License tiers → Get plan usage** — `usage` should be back to the original.
+
+If any of the PATCH calls return 401 with the `user:update:user:admin` scope
+error, see the gotcha box above.

--- a/docs/postman/baton-zoom.postman_collection.json
+++ b/docs/postman/baton-zoom.postman_collection.json
@@ -1,0 +1,438 @@
+{
+	"info": {
+		"_postman_id": "f4e0a7c2-21c5-4f37-9a3a-7c81d1e3f000",
+		"name": "baton-zoom",
+		"description": "Zoom REST API endpoints used by the baton-zoom connector. Covers Server-to-Server OAuth, users, license tier management, groups, roles, contact groups, invites, and plan usage.\n\n## Setup\n\n1. Import this collection and the matching environment (`baton-zoom.postman_environment.json`).\n2. Fill in the environment variables `accountId`, `clientId`, `clientSecret`.\n3. Run the **Auth → Get access token** request first. Its test script writes `accessToken` to the active environment, and every other request in this collection uses it as a Bearer token via collection-level auth.\n4. Tokens are valid for 1 hour. Re-run **Get access token** whenever requests start returning HTTP 401.\n\n## Required Zoom OAuth scopes (granular)\n\n| Folder | Scopes |\n|---|---|\n| Users | `user:read:list_users:admin`, `user:read:user:admin`, `user:write:user:admin`, `user:delete:user:admin` |\n| License tiers | `user:read:user:admin`, `user:update:user:admin` (note: `user:write:user:admin` only covers POST /v2/users; PATCH needs the separate `user:update:user:admin` scope) |\n| Plan usage | `billing:read:plan_usage:admin` |\n| Groups | `group:read:list_groups:admin`, `group:read:list_members:admin`, `group:read:administrator:admin`, `group:write:member:admin`, `group:delete:member:admin`, `group:write:administrator:admin`, `group:delete:administrator:admin` |\n| Roles | `role:read:list_roles:admin`, `role:read:list_members:admin`, `role:write:member:admin`, `role:delete:member:admin` |\n| Contact groups | `contact_group:read:list_groups:admin`, `contact_group:read:list_members:admin` |\n",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "{{accessToken}}",
+				"type": "string"
+			}
+		]
+	},
+	"item": [
+		{
+			"name": "Auth",
+			"item": [
+				{
+					"name": "Get access token (S2S OAuth)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test('Status is 200', () => pm.response.to.have.status(200));",
+									"const body = pm.response.json();",
+									"pm.test('Body contains access_token', () => pm.expect(body).to.have.property('access_token'));",
+									"pm.environment.set('accessToken', body.access_token);",
+									"console.log('Scopes granted:', body.scope);"
+								]
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{ "key": "username", "value": "{{clientId}}", "type": "string" },
+								{ "key": "password", "value": "{{clientSecret}}", "type": "string" }
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "https://zoom.us/oauth/token?grant_type=account_credentials&account_id={{accountId}}",
+							"protocol": "https",
+							"host": ["zoom", "us"],
+							"path": ["oauth", "token"],
+							"query": [
+								{ "key": "grant_type", "value": "account_credentials" },
+								{ "key": "account_id", "value": "{{accountId}}" }
+							]
+						},
+						"description": "Server-to-Server OAuth token. Uses Basic Auth with `clientId:clientSecret` and account_credentials grant. Writes the returned token to the `accessToken` environment variable.\n\nDocs: https://developers.zoom.us/docs/internal-apps/s2s-oauth/"
+					}
+				}
+			]
+		},
+		{
+			"name": "Users",
+			"item": [
+				{
+					"name": "List users (active)",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users?status=active&page_size=30",
+							"host": ["{{baseUrl}}"],
+							"path": ["users"],
+							"query": [
+								{ "key": "status", "value": "active" },
+								{ "key": "page_size", "value": "30" },
+								{ "key": "next_page_token", "value": "", "disabled": true }
+							]
+						},
+						"description": "Lists active users. Use `next_page_token` for pagination. Scope: `user:read:list_users:admin`."
+					}
+				},
+				{
+					"name": "List users (inactive)",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users?status=inactive&page_size=30",
+							"host": ["{{baseUrl}}"],
+							"path": ["users"],
+							"query": [
+								{ "key": "status", "value": "inactive" },
+								{ "key": "page_size", "value": "30" }
+							]
+						},
+						"description": "Lists deactivated users. The connector emits these when `--sync-inactive-users` is set."
+					}
+				},
+				{
+					"name": "Get user (me)",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/me",
+							"host": ["{{baseUrl}}"],
+							"path": ["users", "me"]
+						},
+						"description": "Returns the user that owns the OAuth credentials. Used by `Validate()` to confirm the connector has admin scope.\n\nScope: `user:read:user:admin`."
+					}
+				},
+				{
+					"name": "Get user (by ID)",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/{{userId}}",
+							"host": ["{{baseUrl}}"],
+							"path": ["users", "{{userId}}"]
+						},
+						"description": "Fetches a single user. The connector calls this before Grant/Revoke to verify the user exists and is active.\n\nScope: `user:read:user:admin`."
+					}
+				},
+				{
+					"name": "Create user",
+					"request": {
+						"method": "POST",
+						"header": [
+							{ "key": "Content-Type", "value": "application/json" }
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"action\": \"create\",\n  \"user_info\": {\n    \"type\": 1,\n    \"email\": \"test.user@example.com\",\n    \"first_name\": \"Test\",\n    \"last_name\": \"User\",\n    \"display_name\": \"Test User\"\n  }\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/users",
+							"host": ["{{baseUrl}}"],
+							"path": ["users"]
+						},
+						"description": "Creates a new Zoom user. `type` 1=Basic, 2=Licensed, 3=On-Prem.\n\nScope: `user:write:user:admin` (note: this is the CREATE scope only — PATCH requires `user:update:user:admin`)."
+					}
+				},
+				{
+					"name": "Delete user",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/{{userId}}?action=delete",
+							"host": ["{{baseUrl}}"],
+							"path": ["users", "{{userId}}"],
+							"query": [
+								{ "key": "action", "value": "delete", "description": "delete | disassociate" }
+							]
+						},
+						"description": "Removes a user from the account. `action=delete` removes the user entirely; `action=disassociate` keeps the account but unlinks it.\n\nScope: `user:delete:user:admin`."
+					}
+				}
+			]
+		},
+		{
+			"name": "License tiers",
+			"description": "Endpoints exercised by the `license` resource type. Grant maps to PATCH with `type=N`; Revoke maps to PATCH with `type=1` (downgrade to Basic).",
+			"item": [
+				{
+					"name": "Get plan usage (seat counts)",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/accounts/me/plans/usage",
+							"host": ["{{baseUrl}}"],
+							"path": ["accounts", "me", "plans", "usage"]
+						},
+						"description": "Returns `plan_base.hosts` (purchased Licensed seats) and `plan_base.usage` (consumed). The connector populates these into the `LicenseProfileTrait` of the Licensed tier resource. Optional — `licenseResourceType.List()` degrades gracefully if this scope is missing.\n\nScope: `billing:read:plan_usage:admin`.\n\nDocs: https://developers.zoom.us/docs/api/billing/ma/ (search 'Get plan usage')."
+					}
+				},
+				{
+					"name": "Grant Licensed tier (PATCH type=2)",
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{ "key": "Content-Type", "value": "application/json" }
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"type\": 2\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/users/{{userId}}",
+							"host": ["{{baseUrl}}"],
+							"path": ["users", "{{userId}}"]
+						},
+						"description": "Upgrades a user to the Licensed tier. Returns HTTP 204 on success. Consumes a paid seat from `plan_base.hosts`.\n\nScope: `user:update:user:admin` (NOT `user:write:user:admin`)."
+					}
+				},
+				{
+					"name": "Revoke / downgrade to Basic (PATCH type=1)",
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{ "key": "Content-Type", "value": "application/json" }
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"type\": 1\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/users/{{userId}}",
+							"host": ["{{baseUrl}}"],
+							"path": ["users", "{{userId}}"]
+						},
+						"description": "Downgrades a user back to Basic. This is what the connector's `Revoke(license:2:assigned, user:...)` does — Zoom has no 'remove license' verb, so Revoke is implemented as a tier change.\n\nScope: `user:update:user:admin`."
+					}
+				},
+				{
+					"name": "Set On-Prem tier (PATCH type=3)",
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{ "key": "Content-Type", "value": "application/json" }
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"type\": 3\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/users/{{userId}}",
+							"host": ["{{baseUrl}}"],
+							"path": ["users", "{{userId}}"]
+						},
+						"description": "Moves a user to the On-Prem tier (Zoom Phone hardware customers). Less common — the connector exposes this tier as a resource but real grants are rare.\n\nScope: `user:update:user:admin`."
+					}
+				}
+			]
+		},
+		{
+			"name": "Groups",
+			"item": [
+				{
+					"name": "List groups",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/groups",
+							"host": ["{{baseUrl}}"],
+							"path": ["groups"]
+						},
+						"description": "Scope: `group:read:list_groups:admin`."
+					}
+				},
+				{
+					"name": "List group members",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/groups/{{groupId}}/members?page_size=30",
+							"host": ["{{baseUrl}}"],
+							"path": ["groups", "{{groupId}}", "members"],
+							"query": [
+								{ "key": "page_size", "value": "30" },
+								{ "key": "next_page_token", "value": "", "disabled": true }
+							]
+						},
+						"description": "Scope: `group:read:list_members:admin`."
+					}
+				},
+				{
+					"name": "List group admins",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/groups/{{groupId}}/admins",
+							"host": ["{{baseUrl}}"],
+							"path": ["groups", "{{groupId}}", "admins"]
+						},
+						"description": "Scope: `group:read:administrator:admin`."
+					}
+				},
+				{
+					"name": "Add group members",
+					"request": {
+						"method": "POST",
+						"header": [
+							{ "key": "Content-Type", "value": "application/json" }
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"members\": [\n    { \"id\": \"{{userId}}\" }\n  ]\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/groups/{{groupId}}/members",
+							"host": ["{{baseUrl}}"],
+							"path": ["groups", "{{groupId}}", "members"]
+						},
+						"description": "Scope: `group:write:member:admin`."
+					}
+				},
+				{
+					"name": "Remove group member",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/groups/{{groupId}}/members/{{userId}}",
+							"host": ["{{baseUrl}}"],
+							"path": ["groups", "{{groupId}}", "members", "{{userId}}"]
+						},
+						"description": "Scope: `group:delete:member:admin`."
+					}
+				}
+			]
+		},
+		{
+			"name": "Roles",
+			"item": [
+				{
+					"name": "List roles",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/roles",
+							"host": ["{{baseUrl}}"],
+							"path": ["roles"]
+						},
+						"description": "Scope: `role:read:list_roles:admin`."
+					}
+				},
+				{
+					"name": "List role members",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/roles/{{roleId}}/members",
+							"host": ["{{baseUrl}}"],
+							"path": ["roles", "{{roleId}}", "members"]
+						},
+						"description": "Scope: `role:read:list_members:admin`."
+					}
+				},
+				{
+					"name": "Add member to role",
+					"request": {
+						"method": "POST",
+						"header": [
+							{ "key": "Content-Type", "value": "application/json" }
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"members\": [\n    { \"id\": \"{{userId}}\" }\n  ]\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/roles/{{roleId}}/members",
+							"host": ["{{baseUrl}}"],
+							"path": ["roles", "{{roleId}}", "members"]
+						},
+						"description": "Scope: `role:write:member:admin`."
+					}
+				},
+				{
+					"name": "Remove member from role",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/roles/{{roleId}}/members/{{userId}}",
+							"host": ["{{baseUrl}}"],
+							"path": ["roles", "{{roleId}}", "members", "{{userId}}"]
+						},
+						"description": "Scope: `role:delete:member:admin`."
+					}
+				}
+			]
+		},
+		{
+			"name": "Contact groups",
+			"item": [
+				{
+					"name": "List contact groups",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/contacts/groups",
+							"host": ["{{baseUrl}}"],
+							"path": ["contacts", "groups"]
+						},
+						"description": "Scope: `contact_group:read:list_groups:admin`."
+					}
+				},
+				{
+					"name": "List contact group members",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/contacts/groups/{{contactGroupId}}/members",
+							"host": ["{{baseUrl}}"],
+							"path": ["contacts", "groups", "{{contactGroupId}}", "members"]
+						},
+						"description": "Scope: `contact_group:read:list_members:admin`."
+					}
+				}
+			]
+		},
+		{
+			"name": "Invites (pending users)",
+			"item": [
+				{
+					"name": "List pending users",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users?status=pending&page_size=30",
+							"host": ["{{baseUrl}}"],
+							"path": ["users"],
+							"query": [
+								{ "key": "status", "value": "pending" },
+								{ "key": "page_size", "value": "30" }
+							]
+						},
+						"description": "Users who were invited but haven't accepted yet — surfaced by the `invite` resource type. They have no permanent user ID.\n\nScope: `user:read:list_users:admin`."
+					}
+				}
+			]
+		}
+	]
+}

--- a/docs/postman/baton-zoom.postman_collection.json
+++ b/docs/postman/baton-zoom.postman_collection.json
@@ -141,7 +141,7 @@
 							"host": ["{{baseUrl}}"],
 							"path": ["users"]
 						},
-						"description": "Creates a new Zoom user. `type` 1=Basic, 2=Licensed, 3=On-Prem.\n\nScope: `user:write:user:admin` (note: this is the CREATE scope only — PATCH requires `user:update:user:admin`)."
+						"description": "Creates a new Zoom user. `type` 1=Basic, 2=Licensed, 4=Unassigned without Meetings Basic.\n\nScope: `user:write:user:admin` (note: this is the CREATE scope only — PATCH requires `user:update:user:admin`)."
 					}
 				},
 				{
@@ -218,7 +218,7 @@
 					}
 				},
 				{
-					"name": "Set On-Prem tier (PATCH type=3)",
+					"name": "Set Unassigned tier (PATCH type=4)",
 					"request": {
 						"method": "PATCH",
 						"header": [
@@ -226,14 +226,14 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"type\": 3\n}"
+							"raw": "{\n  \"type\": 4\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/users/{{userId}}",
 							"host": ["{{baseUrl}}"],
 							"path": ["users", "{{userId}}"]
 						},
-						"description": "Moves a user to the On-Prem tier (Zoom Phone hardware customers). Less common — the connector exposes this tier as a resource but real grants are rare.\n\nScope: `user:update:user:admin`."
+						"description": "Moves a user to the Unassigned without Meetings Basic tier (aka No Meetings License): keeps the account seat but removes the meetings license.\n\nScope: `user:update:user:admin`."
 					}
 				}
 			]

--- a/docs/postman/baton-zoom.postman_environment.json
+++ b/docs/postman/baton-zoom.postman_environment.json
@@ -1,0 +1,62 @@
+{
+  "id": "f4e0a7c2-21c5-4f37-9a3a-7c81d1e3f001",
+  "name": "baton-zoom",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "https://api.zoom.us/v2",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "accountId",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "clientId",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "clientSecret",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "accessToken",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "userId",
+      "value": "me",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "groupId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "roleId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "contactGroupId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_using": "Postman/10"
+}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -12,90 +12,6 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 )
 
-const userStatusInactive = "inactive"
-
-var (
-	resourceTypeUser = &v2.ResourceType{
-		Id:          "user",
-		DisplayName: "User",
-		Traits: []v2.ResourceType_Trait{
-			v2.ResourceType_TRAIT_USER,
-		},
-		Annotations: annotations.New(
-			&v2.CapabilityPermissions{
-				Permissions: []*v2.CapabilityPermission{
-					{Permission: "user:read:user:admin"},
-					{Permission: "user:read:list_users:admin"},
-					{Permission: "user:write:user:admin"},
-					{Permission: "user:delete:user:admin"},
-				},
-			},
-			&v2.SkipEntitlementsAndGrants{},
-		),
-	}
-	resourceTypeGroup = &v2.ResourceType{
-		Id:          "group",
-		DisplayName: "Group",
-		Traits: []v2.ResourceType_Trait{
-			v2.ResourceType_TRAIT_GROUP,
-		},
-		Annotations: annotations.New(&v2.CapabilityPermissions{
-			Permissions: []*v2.CapabilityPermission{
-				{Permission: "group:read:list_groups:admin"},
-				{Permission: "group:read:list_members:admin"},
-				{Permission: "group:read:administrator:admin"},
-				{Permission: "group:write:member:admin"},
-				{Permission: "group:delete:member:admin"},
-				{Permission: "group:write:administrator:admin"},
-				{Permission: "group:delete:administrator:admin"},
-			},
-		}),
-	}
-	resourceTypeContactGroup = &v2.ResourceType{
-		Id:          "contactGroup",
-		DisplayName: "Contact Group",
-		Traits: []v2.ResourceType_Trait{
-			v2.ResourceType_TRAIT_GROUP,
-		},
-		Annotations: annotations.New(&v2.CapabilityPermissions{
-			Permissions: []*v2.CapabilityPermission{
-				{Permission: "contact_group:read:list_groups:admin"},
-				{Permission: "contact_group:read:list_members:admin"},
-			},
-		}),
-	}
-	resourceTypeInvite = &v2.ResourceType{
-		Id:          "invite",
-		DisplayName: "Invite",
-		Traits: []v2.ResourceType_Trait{
-			v2.ResourceType_TRAIT_USER,
-		},
-		Annotations: annotations.New(
-			&v2.CapabilityPermissions{
-				Permissions: []*v2.CapabilityPermission{
-					{Permission: "user:read:list_users:admin"},
-				},
-			},
-			&v2.SkipEntitlementsAndGrants{},
-		),
-	}
-	resourceTypeRole = &v2.ResourceType{
-		Id:          "role",
-		DisplayName: "Role",
-		Traits: []v2.ResourceType_Trait{
-			v2.ResourceType_TRAIT_ROLE,
-		},
-		Annotations: annotations.New(&v2.CapabilityPermissions{
-			Permissions: []*v2.CapabilityPermission{
-				{Permission: "role:read:list_roles:admin"},
-				{Permission: "role:read:list_members:admin"},
-				{Permission: "role:write:member:admin"},
-				{Permission: "role:delete:member:admin"},
-			},
-		}),
-	}
-)
-
 type Zoom struct {
 	client            *zoom.Client
 	syncInactiveUsers bool
@@ -132,7 +48,7 @@ func New(
 func (z *Zoom) Metadata(_ context.Context) (*v2.ConnectorMetadata, error) {
 	return &v2.ConnectorMetadata{
 		DisplayName: "Zoom",
-		Description: "Connector syncing users, groups, roles and contact groups from Zoom to Baton.",
+		Description: "Connector syncing users, groups, roles, contact groups, and license tiers from Zoom to Baton.",
 		AccountCreationSchema: &v2.ConnectorAccountCreationSchema{
 			FieldMap: map[string]*v2.ConnectorAccountCreationSchema_Field{
 				"email": {
@@ -206,5 +122,6 @@ func (z *Zoom) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceS
 		groupBuilder(z.client),
 		roleBuilder(z.client),
 		contactGroupBuilder(z.client),
+		licenseBuilder(z.client, z.syncInactiveUsers),
 	}
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -122,6 +122,6 @@ func (z *Zoom) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceS
 		groupBuilder(z.client),
 		roleBuilder(z.client),
 		contactGroupBuilder(z.client),
-		licenseBuilder(z.client, z.syncInactiveUsers),
+		licenseBuilder(z.client),
 	}
 }

--- a/pkg/connector/contactGroup.go
+++ b/pkg/connector/contactGroup.go
@@ -22,7 +22,7 @@ func (g *contactGroupResourceType) ResourceType(_ context.Context) *v2.ResourceT
 
 // Create a new connector resource for a Zoom group.
 func contactGroupResource(group zoom.ContactGroup, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
-	profile := map[string]interface{}{
+	profile := map[string]any{
 		"group_name": group.Name,
 		"group_id":   group.ID,
 	}

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -31,7 +31,7 @@ func (g *groupResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 
 // Create a new connector resource for a Zoom group.
 func groupResource(group zoom.Group, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
-	profile := map[string]interface{}{
+	profile := map[string]any{
 		"group_name": group.Name,
 		"group_id":   group.ID,
 	}

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	firstNameKey = "first_name"
-	lastNameKey  = "last_name"
+	firstNameKey       = "first_name"
+	lastNameKey        = "last_name"
+	userStatusActive   = "active"
+	userStatusInactive = "inactive"
 )
 
 func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, string, error) {
@@ -86,4 +88,3 @@ func parseResp(resp *http.Response) (annotations.Annotations, error) {
 
 	return annos, nil
 }
-

--- a/pkg/connector/invite.go
+++ b/pkg/connector/invite.go
@@ -20,7 +20,7 @@ func (i *inviteResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 // inviteResource creates a connector resource for a pending Zoom user (invite).
 // Pending users have no Zoom ID yet, so the email is used as the stable resource identifier.
 func inviteResource(user zoom.User, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
-	profile := map[string]interface{}{
+	profile := map[string]any{
 		firstNameKey: user.FirstName,
 		lastNameKey:  user.LastName,
 		"login":      user.Email,

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -1,5 +1,76 @@
 package connector
 
+// License management for the Zoom connector.
+//
+// Endpoints used:
+//   - GET   /v2/users                       - List users; User.type carries the per-user license tier
+//   - GET   /v2/users/{userId}              - Pre-flight check before Grant/Revoke (idempotency)
+//   - GET   /v2/accounts/me/plans/usage     - Account-level seat counts for the Licensed tier
+//   - PATCH /v2/users/{userId}              - Change a user's tier (Grant / Revoke)
+//
+// Authentication: Server-to-Server OAuth, granular scopes:
+//   - user:read:list_users:admin    - List users
+//   - user:read:user:admin          - Get a single user (pre-flight before PATCH)
+//   - user:update:user:admin        - PATCH a user's tier
+//   - billing:read:plan_usage:admin - Plan usage (optional; enables Licensed seat counts)
+//
+// Official API references:
+//   - Users API:        https://developers.zoom.us/docs/api/users/
+//   - Update User:      https://developers.zoom.us/docs/api/users/#tag/users/patch/users/{userId}
+//   - Plan Usage:       https://developers.zoom.us/docs/api/billing/ma/
+//   - Remaining seats:  https://devforum.zoom.us/t/30341  (community-validated formula)
+//
+// How Zoom licensing works (and how this connector models it):
+//
+//  1. License tier is a USER property, not a separate resource. Each user has
+//     a `type` field on GET /v2/users with one of these values:
+//
+//       type=1  Basic     - Free tier, uncapped, anyone can sign up. Floor tier.
+//       type=2  Licensed  - Paid base-plan seat (consumes 1 from plan_base).
+//       type=3  On-Prem   - Provisioned via Meeting Connector (self-hosted).
+//       type=99 None      - No license assigned (transitional, rare).
+//
+//  2. Zoom does NOT expose a /licenses endpoint. The 3 tiers are fixed and the
+//     API references them only by integer code, so this connector models them
+//     as STATIC resources hardcoded in licenseDefinitions.
+//
+//  3. License grants are emitted PRINCIPAL-SIDE from userBuilder.Grants (using
+//     User.type stashed in the user profile during List), not from
+//     licenseResourceType.Grants. Each user holds exactly one tier, so a
+//     single user pagination sweep produces all license grants — emitting
+//     from the license side would require an O(N × tiers) scan.
+//
+//  4. Seat counts only attach to the Licensed tier resource:
+//
+//       plan_base.hosts = Licensed seats purchased (the cap)
+//       plan_base.usage = Licensed seats consumed  (= count(User.type == 2))
+//
+//     Basic is uncapped (Zoom doesn't track it; nothing to surface). On-Prem
+//     is provisioned outside Zoom Cloud (the billing API has no visibility
+//     into it). The identity plan_base.usage == count(User.type == 2) was
+//     validated end-to-end against a live Business-Monthly tenant on every
+//     state transition (Grant → usage++; Revoke → usage--; idempotent
+//     re-Grant/Revoke → no change).
+//
+//  5. Grant / Revoke both PATCH /v2/users/{userId} with {"type": N}. Revoke
+//     downgrades to Basic because Zoom has no "no license" state — Basic is
+//     the floor tier. Three short-circuits keep the operations idempotent
+//     (each backed by a single pre-flight GET, no extra PATCH):
+//
+//       Grant of the user's current tier         → GrantAlreadyExists,  no PATCH
+//       Revoke of a tier the user no longer holds → GrantAlreadyRevoked, no PATCH
+//       Revoke of Basic (the floor tier)         → GrantAlreadyRevoked, no PATCH
+//
+// Out of scope (deliberately not modeled in C1):
+//   - Add-on plan seats (plan_webinar, plan_large_meeting, plan_zoom_one,
+//     plan_phone, plan_recording, ...): they don't change User.type and
+//     aren't grantable as identity entitlements.
+//   - Master account / reseller flows: /plans/usage returns plan_base as
+//     an array there with active_hosts in place of usage. This connector
+//     assumes the "accounts/me" sub-account shape.
+//   - On-Prem deployment internals: Meeting Connector is self-hosted and
+//     opaque to the billing API.
+
 import (
 	"context"
 	"fmt"
@@ -7,9 +78,7 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
-	grant "github.com/conductorone/baton-sdk/pkg/types/grant"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-zoom/pkg/zoom"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -20,16 +89,14 @@ const (
 	assignedEntitlement = "assigned"
 )
 
-// licenseDefinition describes one of Zoom's three license tiers. Zoom does
-// not expose a "list licenses" endpoint — the tiers are fixed and the API
-// references them by integer code on the User.type field.
+// licenseDefinition is one Zoom license tier (id + display name).
 type licenseDefinition struct {
 	id   zoom.UserType
 	name string
 }
 
-// licenseDefinitions enumerates the tiers we model. Order is preserved when
-// rendering List results for deterministic output.
+// licenseDefinitions is the static catalog of tiers we model. Order is
+// preserved on List for deterministic output.
 var licenseDefinitions = []licenseDefinition{
 	{id: zoom.BasicUser, name: "Basic"},
 	{id: zoom.LicensedUser, name: "Licensed"},
@@ -37,22 +104,30 @@ var licenseDefinitions = []licenseDefinition{
 }
 
 type licenseResourceType struct {
-	resourceType      *v2.ResourceType
-	client            *zoom.Client
-	syncInactiveUsers bool
+	resourceType *v2.ResourceType
+	client       *zoom.Client
 }
 
 func (l *licenseResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 	return l.resourceType
 }
 
-// licenseResource builds a connector resource for a single Zoom license
-// tier. Purchased and consumed seat counts come from
-// GET /v2/accounts/me/plans/usage and are only meaningful for the Licensed
-// tier (Basic seats are free and On-Prem is provisioned outside Zoom Cloud).
+// licenseResource builds a connector resource for one license tier.
+// Seat counts attach only to the Licensed tier. EntitlementIDs links
+// the seat counts back to the grants that consume them so the C1 App
+// Utilization feature (CE-720) can map consumed_seats to user grants
+// without manual entitlement mapping.
 func licenseResource(def licenseDefinition, purchased, consumed int64) (*v2.Resource, error) {
+	licenseID := strconv.Itoa(int(def.id))
+
+	assignedEntitlementID := ent.NewEntitlementID(
+		&v2.Resource{Id: &v2.ResourceId{ResourceType: resourceTypeLicense.Id, Resource: licenseID}},
+		assignedEntitlement,
+	)
+
 	licenseOpts := []resource.LicenseProfileTraitOption{
 		resource.WithLicenseName(def.name),
+		resource.WithLicenseEntitlementIDs(assignedEntitlementID),
 	}
 
 	if def.id == zoom.LicensedUser && purchased > 0 {
@@ -62,16 +137,14 @@ func licenseResource(def licenseDefinition, purchased, consumed int64) (*v2.Reso
 	return resource.NewResource(
 		def.name,
 		resourceTypeLicense,
-		strconv.Itoa(int(def.id)),
+		licenseID,
 		resource.WithLicenseProfileTrait(licenseOpts...),
 	)
 }
 
-// List returns the three static license tiers. Seat counts for the Licensed
-// tier are best-effort: if the billing scope is missing or the call fails
-// the tier is still emitted, just without seat numbers. This keeps sync
-// usable for accounts where the operator hasn't (yet) granted
-// billing:read:plan_usage:admin.
+// List returns the three static license tiers. The plan_base fetch is
+// best-effort: if the billing scope is missing or the call fails, the
+// tiers are still emitted, just without seat numbers on Licensed.
 func (l *licenseResourceType) List(ctx context.Context, _ *v2.ResourceId, _ resource.SyncOpAttrs) ([]*v2.Resource, *resource.SyncOpResults, error) {
 	logger := ctxzap.Extract(ctx)
 
@@ -81,8 +154,6 @@ func (l *licenseResourceType) List(ctx context.Context, _ *v2.ResourceId, _ reso
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		// Treat plan-usage failures as non-fatal: seat counts are an
-		// observability nicety, not required for grant evaluation.
 		logger.Warn(
 			"baton-zoom: failed to fetch plan usage; emitting licenses without seat counts",
 			zap.Error(err),
@@ -109,10 +180,8 @@ func (l *licenseResourceType) List(ctx context.Context, _ *v2.ResourceId, _ reso
 	return rv, &resource.SyncOpResults{Annotations: annos}, nil
 }
 
-// Entitlements emits a single "assigned" assignment-purpose entitlement per
-// license tier. Each Zoom user holds exactly one license at a time, so
-// grants are mutually exclusive across tiers but expressed as independent
-// entitlements per resource.
+// Entitlements emits the single "assigned" assignment-purpose entitlement
+// per license tier (each user holds exactly one tier).
 func (l *licenseResourceType) Entitlements(_ context.Context, res *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
 	opts := []ent.EntitlementOption{
 		ent.WithGrantableTo(resourceTypeUser),
@@ -124,89 +193,17 @@ func (l *licenseResourceType) Entitlements(_ context.Context, res *v2.Resource, 
 	return []*v2.Entitlement{en}, &resource.SyncOpResults{}, nil
 }
 
-// Grants paginates over Zoom users (active, plus inactive when configured)
-// and emits one grant per user whose User.type matches the license tier
-// being synced. The same status-stack pagination pattern used by userResourceType
-// is used here to avoid an extra GET /v2/users/{id} per user.
-func (l *licenseResourceType) Grants(ctx context.Context, res *v2.Resource, opts resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
-	licenseID, err := strconv.Atoi(res.Id.Resource)
-	if err != nil {
-		return nil, nil, fmt.Errorf("baton-zoom: invalid license resource id %q: %w", res.Id.Resource, err)
-	}
-
-	bag := &pagination.Bag{}
-	if err := bag.Unmarshal(opts.PageToken.Token); err != nil {
-		return nil, nil, err
-	}
-
-	if bag.Current() == nil {
-		if l.syncInactiveUsers {
-			bag.Push(pagination.PageState{ResourceTypeID: resourceTypeLicense.Id, ResourceID: userStatusInactive})
-		}
-		bag.Push(pagination.PageState{ResourceTypeID: resourceTypeLicense.Id, ResourceID: userStatusActive})
-	}
-
-	status := bag.Current().ResourceID
-	page := bag.PageToken()
-
-	users, nextPage, resp, err := l.client.GetUsers(ctx, page, status)
-	if err != nil {
-		if resp != nil {
-			resp.Body.Close()
-		}
-		return nil, nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := bag.Next(nextPage); err != nil {
-		return nil, nil, err
-	}
-
-	pageToken, err := bag.Marshal()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	annos, err := parseResp(resp)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var rv []*v2.Grant
-	for _, u := range users {
-		if u.Type != licenseID {
-			continue
-		}
-		principalID := &v2.ResourceId{
-			ResourceType: resourceTypeUser.Id,
-			Resource:     u.ID,
-		}
-		rv = append(rv, grant.NewGrant(res, assignedEntitlement, principalID))
-	}
-
-	return rv, &resource.SyncOpResults{NextPageToken: pageToken, Annotations: annos}, nil
+// Grants is a no-op: license grants are emitted from userBuilder.Grants.
+func (l *licenseResourceType) Grants(_ context.Context, _ *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
+	return nil, &resource.SyncOpResults{}, nil
 }
 
-// Grant applies a license by PATCHing the user's `type` field.
-//
-// Idempotency follows the "Role Idempotency via User State" pattern from the
-// baton-provisioning skill: a pre-flight GET resolves the user's current tier
-// and short-circuits with GrantAlreadyExists when the target tier already
-// matches, avoiding an unnecessary PATCH.
-//
-// Every other rejection (deactivated user, missing scope, malformed payload,
-// etc.) is left to the Zoom API and propagated verbatim. The connector does
-// not pre-judge user state — Zoom is the source of truth.
+// Grant assigns a license tier to a user via PATCH /v2/users/{userId}.
+// A pre-flight GET resolves the current tier and short-circuits with
+// GrantAlreadyExists when the target tier already matches.
 func (l *licenseResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) ([]*v2.Grant, annotations.Annotations, error) {
-	logger := ctxzap.Extract(ctx)
-
 	if principal.Id.ResourceType != resourceTypeUser.Id {
-		logger.Warn(
-			"baton-zoom: only users can be granted a license",
-			zap.String("principal_type", principal.Id.ResourceType),
-			zap.String("principal_id", principal.Id.Resource),
-		)
-		return nil, nil, fmt.Errorf("baton-zoom: only users can be granted a license")
+		return nil, nil, fmt.Errorf("baton-zoom: only users can be granted a license (got %q)", principal.Id.ResourceType)
 	}
 
 	targetType, err := strconv.Atoi(entitlement.Resource.Id.Resource)
@@ -234,27 +231,15 @@ func (l *licenseResourceType) Grant(ctx context.Context, principal *v2.Resource,
 	return nil, nil, nil
 }
 
-// Revoke downgrades the user to Basic via PATCH `type=1` (Zoom has no
-// "no license" state — Basic is the floor tier).
-//
-// Returns GrantAlreadyRevoked without an API call when:
-//   1. The user no longer holds the tier being revoked.
-//   2. The tier being revoked is Basic — no lower tier exists, so it's a no-op.
-//
-// All other Zoom errors are propagated verbatim.
+// Revoke downgrades the user to Basic via PATCH (Zoom has no "no license"
+// state). Returns GrantAlreadyRevoked without an API call when the user
+// no longer holds the tier or when the revoked tier is Basic itself.
 func (l *licenseResourceType) Revoke(ctx context.Context, g *v2.Grant) (annotations.Annotations, error) {
-	logger := ctxzap.Extract(ctx)
-
 	entitlement := g.Entitlement
 	principal := g.Principal
 
 	if principal.Id.ResourceType != resourceTypeUser.Id {
-		logger.Warn(
-			"baton-zoom: only users can have a license revoked",
-			zap.String("principal_type", principal.Id.ResourceType),
-			zap.String("principal_id", principal.Id.Resource),
-		)
-		return nil, fmt.Errorf("baton-zoom: only users can have a license revoked")
+		return nil, fmt.Errorf("baton-zoom: only users can have a license revoked (got %q)", principal.Id.ResourceType)
 	}
 
 	grantedType, err := strconv.Atoi(entitlement.Resource.Id.Resource)
@@ -286,10 +271,9 @@ func (l *licenseResourceType) Revoke(ctx context.Context, g *v2.Grant) (annotati
 	return nil, nil
 }
 
-func licenseBuilder(client *zoom.Client, syncInactiveUsers bool) *licenseResourceType {
+func licenseBuilder(client *zoom.Client) *licenseResourceType {
 	return &licenseResourceType{
-		resourceType:      resourceTypeLicense,
-		client:            client,
-		syncInactiveUsers: syncInactiveUsers,
+		resourceType: resourceTypeLicense,
+		client:       client,
 	}
 }

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -1,0 +1,293 @@
+package connector
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
+	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	grant "github.com/conductorone/baton-sdk/pkg/types/grant"
+	"github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-zoom/pkg/zoom"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+)
+
+const (
+	assignedEntitlement = "assigned"
+)
+
+// licenseDefinition describes one of Zoom's three license tiers. Zoom does
+// not expose a "list licenses" endpoint — the tiers are fixed and the API
+// references them by integer code on the User.type field.
+type licenseDefinition struct {
+	id   zoom.UserType
+	name string
+}
+
+// licenseDefinitions enumerates the tiers we model. Order is preserved when
+// rendering List results for deterministic output.
+var licenseDefinitions = []licenseDefinition{
+	{id: zoom.BasicUser, name: "Basic"},
+	{id: zoom.LicensedUser, name: "Licensed"},
+	{id: zoom.OnPremUser, name: "On-Prem"},
+}
+
+type licenseResourceType struct {
+	resourceType      *v2.ResourceType
+	client            *zoom.Client
+	syncInactiveUsers bool
+}
+
+func (l *licenseResourceType) ResourceType(_ context.Context) *v2.ResourceType {
+	return l.resourceType
+}
+
+// licenseResource builds a connector resource for a single Zoom license
+// tier. Purchased and consumed seat counts come from
+// GET /v2/accounts/me/plans/usage and are only meaningful for the Licensed
+// tier (Basic seats are free and On-Prem is provisioned outside Zoom Cloud).
+func licenseResource(def licenseDefinition, purchased, consumed int64) (*v2.Resource, error) {
+	licenseOpts := []resource.LicenseProfileTraitOption{
+		resource.WithLicenseName(def.name),
+	}
+
+	if def.id == zoom.LicensedUser && purchased > 0 {
+		licenseOpts = append(licenseOpts, resource.WithLicenseSeats(purchased, consumed))
+	}
+
+	return resource.NewResource(
+		def.name,
+		resourceTypeLicense,
+		strconv.Itoa(int(def.id)),
+		resource.WithLicenseProfileTrait(licenseOpts...),
+	)
+}
+
+// List returns the three static license tiers. Seat counts for the Licensed
+// tier are best-effort: if the billing scope is missing or the call fails
+// the tier is still emitted, just without seat numbers. This keeps sync
+// usable for accounts where the operator hasn't (yet) granted
+// billing:read:plan_usage:admin.
+func (l *licenseResourceType) List(ctx context.Context, _ *v2.ResourceId, _ resource.SyncOpAttrs) ([]*v2.Resource, *resource.SyncOpResults, error) {
+	logger := ctxzap.Extract(ctx)
+
+	var purchased, consumed int64
+	usage, resp, err := l.client.GetAccountPlanUsage(ctx)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		// Treat plan-usage failures as non-fatal: seat counts are an
+		// observability nicety, not required for grant evaluation.
+		logger.Warn(
+			"baton-zoom: failed to fetch plan usage; emitting licenses without seat counts",
+			zap.Error(err),
+		)
+	} else if usage != nil {
+		purchased = int64(usage.PlanBase.Hosts)
+		consumed = int64(usage.PlanBase.Usage)
+	}
+
+	rv := make([]*v2.Resource, 0, len(licenseDefinitions))
+	for _, def := range licenseDefinitions {
+		lr, err := licenseResource(def, purchased, consumed)
+		if err != nil {
+			return nil, nil, fmt.Errorf("baton-zoom: failed to build license resource %s: %w", def.name, err)
+		}
+		rv = append(rv, lr)
+	}
+
+	annos, err := parseResp(resp)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return rv, &resource.SyncOpResults{Annotations: annos}, nil
+}
+
+// Entitlements emits a single "assigned" assignment-purpose entitlement per
+// license tier. Each Zoom user holds exactly one license at a time, so
+// grants are mutually exclusive across tiers but expressed as independent
+// entitlements per resource.
+func (l *licenseResourceType) Entitlements(_ context.Context, res *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
+	opts := []ent.EntitlementOption{
+		ent.WithGrantableTo(resourceTypeUser),
+		ent.WithDisplayName(fmt.Sprintf("%s license %s", res.DisplayName, assignedEntitlement)),
+		ent.WithDescription(fmt.Sprintf("Holds a %s license seat in Zoom", res.DisplayName)),
+	}
+
+	en := ent.NewAssignmentEntitlement(res, assignedEntitlement, opts...)
+	return []*v2.Entitlement{en}, &resource.SyncOpResults{}, nil
+}
+
+// Grants paginates over Zoom users (active, plus inactive when configured)
+// and emits one grant per user whose User.type matches the license tier
+// being synced. The same status-stack pagination pattern used by userResourceType
+// is used here to avoid an extra GET /v2/users/{id} per user.
+func (l *licenseResourceType) Grants(ctx context.Context, res *v2.Resource, opts resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
+	licenseID, err := strconv.Atoi(res.Id.Resource)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-zoom: invalid license resource id %q: %w", res.Id.Resource, err)
+	}
+
+	bag := &pagination.Bag{}
+	if err := bag.Unmarshal(opts.PageToken.Token); err != nil {
+		return nil, nil, err
+	}
+
+	if bag.Current() == nil {
+		if l.syncInactiveUsers {
+			bag.Push(pagination.PageState{ResourceTypeID: resourceTypeLicense.Id, ResourceID: userStatusInactive})
+		}
+		bag.Push(pagination.PageState{ResourceTypeID: resourceTypeLicense.Id, ResourceID: userStatusActive})
+	}
+
+	status := bag.Current().ResourceID
+	page := bag.PageToken()
+
+	users, nextPage, resp, err := l.client.GetUsers(ctx, page, status)
+	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := bag.Next(nextPage); err != nil {
+		return nil, nil, err
+	}
+
+	pageToken, err := bag.Marshal()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	annos, err := parseResp(resp)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rv []*v2.Grant
+	for _, u := range users {
+		if u.Type != licenseID {
+			continue
+		}
+		principalID := &v2.ResourceId{
+			ResourceType: resourceTypeUser.Id,
+			Resource:     u.ID,
+		}
+		rv = append(rv, grant.NewGrant(res, assignedEntitlement, principalID))
+	}
+
+	return rv, &resource.SyncOpResults{NextPageToken: pageToken, Annotations: annos}, nil
+}
+
+// Grant applies a license by PATCHing the user's `type` field.
+//
+// Idempotency follows the "Role Idempotency via User State" pattern from the
+// baton-provisioning skill: a pre-flight GET resolves the user's current tier
+// and short-circuits with GrantAlreadyExists when the target tier already
+// matches, avoiding an unnecessary PATCH.
+//
+// Every other rejection (deactivated user, missing scope, malformed payload,
+// etc.) is left to the Zoom API and propagated verbatim. The connector does
+// not pre-judge user state — Zoom is the source of truth.
+func (l *licenseResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) ([]*v2.Grant, annotations.Annotations, error) {
+	logger := ctxzap.Extract(ctx)
+
+	if principal.Id.ResourceType != resourceTypeUser.Id {
+		logger.Warn(
+			"baton-zoom: only users can be granted a license",
+			zap.String("principal_type", principal.Id.ResourceType),
+			zap.String("principal_id", principal.Id.Resource),
+		)
+		return nil, nil, fmt.Errorf("baton-zoom: only users can be granted a license")
+	}
+
+	targetType, err := strconv.Atoi(entitlement.Resource.Id.Resource)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-zoom: invalid license resource id %q: %w", entitlement.Resource.Id.Resource, err)
+	}
+
+	user, resp, err := l.client.GetUser(ctx, principal.Id.Resource)
+	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return nil, nil, fmt.Errorf("baton-zoom: failed to get user before granting license: %w", err)
+	}
+	resp.Body.Close()
+
+	if user.Type == targetType {
+		return nil, annotations.New(&v2.GrantAlreadyExists{}), nil
+	}
+
+	if err := l.client.PatchUserLicense(ctx, principal.Id.Resource, zoom.UserType(targetType)); err != nil {
+		return nil, nil, fmt.Errorf("baton-zoom: failed to assign license to user: %w", err)
+	}
+
+	return nil, nil, nil
+}
+
+// Revoke removes a license by downgrading the user back to Basic. Zoom has
+// no concept of "no license" — Basic is the floor tier — so Revoke is
+// implemented as PATCH `type=1`.
+//
+// Idempotency follows the "Role Idempotency via User State" pattern from the
+// baton-provisioning skill: a pre-flight GET short-circuits with
+// GrantAlreadyRevoked when the user no longer holds the tier being revoked.
+//
+// Every other rejection (deactivated user, etc.) is propagated from Zoom
+// verbatim. The connector does not pre-judge user state.
+func (l *licenseResourceType) Revoke(ctx context.Context, g *v2.Grant) (annotations.Annotations, error) {
+	logger := ctxzap.Extract(ctx)
+
+	entitlement := g.Entitlement
+	principal := g.Principal
+
+	if principal.Id.ResourceType != resourceTypeUser.Id {
+		logger.Warn(
+			"baton-zoom: only users can have a license revoked",
+			zap.String("principal_type", principal.Id.ResourceType),
+			zap.String("principal_id", principal.Id.Resource),
+		)
+		return nil, fmt.Errorf("baton-zoom: only users can have a license revoked")
+	}
+
+	grantedType, err := strconv.Atoi(entitlement.Resource.Id.Resource)
+	if err != nil {
+		return nil, fmt.Errorf("baton-zoom: invalid license resource id %q: %w", entitlement.Resource.Id.Resource, err)
+	}
+
+	user, resp, err := l.client.GetUser(ctx, principal.Id.Resource)
+	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return nil, fmt.Errorf("baton-zoom: failed to get user before revoking license: %w", err)
+	}
+	resp.Body.Close()
+
+	if user.Type != grantedType {
+		return annotations.New(&v2.GrantAlreadyRevoked{}), nil
+	}
+
+	if err := l.client.PatchUserLicense(ctx, principal.Id.Resource, zoom.BasicUser); err != nil {
+		return nil, fmt.Errorf("baton-zoom: failed to revoke license from user: %w", err)
+	}
+
+	return nil, nil
+}
+
+func licenseBuilder(client *zoom.Client, syncInactiveUsers bool) *licenseResourceType {
+	return &licenseResourceType{
+		resourceType:      resourceTypeLicense,
+		client:            client,
+		syncInactiveUsers: syncInactiveUsers,
+	}
+}

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -234,16 +234,14 @@ func (l *licenseResourceType) Grant(ctx context.Context, principal *v2.Resource,
 	return nil, nil, nil
 }
 
-// Revoke removes a license by downgrading the user back to Basic. Zoom has
-// no concept of "no license" — Basic is the floor tier — so Revoke is
-// implemented as PATCH `type=1`.
+// Revoke downgrades the user to Basic via PATCH `type=1` (Zoom has no
+// "no license" state — Basic is the floor tier).
 //
-// Idempotency follows the "Role Idempotency via User State" pattern from the
-// baton-provisioning skill: a pre-flight GET short-circuits with
-// GrantAlreadyRevoked when the user no longer holds the tier being revoked.
+// Returns GrantAlreadyRevoked without an API call when:
+//   1. The user no longer holds the tier being revoked.
+//   2. The tier being revoked is Basic — no lower tier exists, so it's a no-op.
 //
-// Every other rejection (deactivated user, etc.) is propagated from Zoom
-// verbatim. The connector does not pre-judge user state.
+// All other Zoom errors are propagated verbatim.
 func (l *licenseResourceType) Revoke(ctx context.Context, g *v2.Grant) (annotations.Annotations, error) {
 	logger := ctxzap.Extract(ctx)
 
@@ -274,6 +272,10 @@ func (l *licenseResourceType) Revoke(ctx context.Context, g *v2.Grant) (annotati
 	resp.Body.Close()
 
 	if user.Type != grantedType {
+		return annotations.New(&v2.GrantAlreadyRevoked{}), nil
+	}
+
+	if grantedType == int(zoom.BasicUser) {
 		return annotations.New(&v2.GrantAlreadyRevoked{}), nil
 	}
 

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -18,21 +18,28 @@ package connector
 //   - Users API:        https://developers.zoom.us/docs/api/users/
 //   - Update User:      https://developers.zoom.us/docs/api/users/#tag/users/patch/users/{userId}
 //   - Plan Usage:       https://developers.zoom.us/docs/api/billing/ma/
-//   - Remaining seats:  https://devforum.zoom.us/t/30341  (community-validated formula)
 //
 // How Zoom licensing works (and how this connector models it):
 //
 //  1. License tier is a USER property, not a separate resource. Each user has
 //     a `type` field on GET /v2/users with one of these values:
 //
-//       type=1  Basic     - Free tier, uncapped, anyone can sign up. Floor tier.
-//       type=2  Licensed  - Paid base-plan seat (consumes 1 from plan_base).
-//       type=3  On-Prem   - Provisioned via Meeting Connector (self-hosted).
-//       type=99 None      - No license assigned (transitional, rare).
+//       type=1  Basic      - Free tier, uncapped, anyone can sign up. Floor tier.
+//       type=2  Licensed   - Paid base-plan seat (consumes 1 from plan_base).
+//       type=4  Unassigned - "Unassigned without Meetings Basic" (aka No
+//                            Meetings License): the user keeps the account
+//                            seat but holds no meetings license. Settable via
+//                            PATCH like any other tier.
 //
-//  2. Zoom does NOT expose a /licenses endpoint. The 3 tiers are fixed and the
-//     API references them only by integer code, so this connector models them
-//     as STATIC resources hardcoded in licenseDefinitions.
+//     The API enum also includes type=99 (None), but it is settable only at
+//     creation via the ssoCreate action — never via PATCH /v2/users/{userId}
+//     — so it cannot participate in the assign/unassign lifecycle and is not
+//     modeled as a tier. Any value outside 1/2/4 emits no license grant.
+//
+//  2. Zoom does NOT expose a /licenses endpoint. The tiers are fixed and the
+//     API references them only by integer code, so this connector models the
+//     three assignable tiers (1, 2, 4) as STATIC resources hardcoded in
+//     licenseDefinitions.
 //
 //  3. License grants are emitted PRINCIPAL-SIDE from userBuilder.Grants (using
 //     User.type stashed in the user profile during List), not from
@@ -45,12 +52,8 @@ package connector
 //       plan_base.hosts = Licensed seats purchased (the cap)
 //       plan_base.usage = Licensed seats consumed  (= count(User.type == 2))
 //
-//     Basic is uncapped (Zoom doesn't track it; nothing to surface). On-Prem
-//     is provisioned outside Zoom Cloud (the billing API has no visibility
-//     into it). The identity plan_base.usage == count(User.type == 2) was
-//     validated end-to-end against a live Business-Monthly tenant on every
-//     state transition (Grant → usage++; Revoke → usage--; idempotent
-//     re-Grant/Revoke → no change).
+//     Basic is uncapped (Zoom doesn't track it; nothing to surface).
+//     Unassigned holds no meetings license, so there is no seat pool to surface.
 //
 //  5. Grant / Revoke both PATCH /v2/users/{userId} with {"type": N}. Revoke
 //     downgrades to Basic because Zoom has no "no license" state — Basic is
@@ -68,8 +71,6 @@ package connector
 //   - Master account / reseller flows: /plans/usage returns plan_base as
 //     an array there with active_hosts in place of usage. This connector
 //     assumes the "accounts/me" sub-account shape.
-//   - On-Prem deployment internals: Meeting Connector is self-hosted and
-//     opaque to the billing API.
 
 import (
 	"context"
@@ -100,7 +101,7 @@ type licenseDefinition struct {
 var licenseDefinitions = []licenseDefinition{
 	{id: zoom.BasicUser, name: "Basic"},
 	{id: zoom.LicensedUser, name: "Licensed"},
-	{id: zoom.OnPremUser, name: "On-Prem"},
+	{id: zoom.UnassignedUser, name: "Unassigned"},
 }
 
 type licenseResourceType struct {
@@ -114,9 +115,8 @@ func (l *licenseResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 
 // licenseResource builds a connector resource for one license tier.
 // Seat counts attach only to the Licensed tier. EntitlementIDs links
-// the seat counts back to the grants that consume them so the C1 App
-// Utilization feature (CE-720) can map consumed_seats to user grants
-// without manual entitlement mapping.
+// the seat counts to the grants that consume them so C1 can map
+// consumed seats to user grants.
 func licenseResource(def licenseDefinition, purchased, consumed int64) (*v2.Resource, error) {
 	licenseID := strconv.Itoa(int(def.id))
 

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -44,7 +44,7 @@ var (
 				scopeUserWrite,
 				scopeUserDelete,
 			),
-			&v2.SkipEntitlementsAndGrants{},
+			&v2.SkipEntitlements{},
 		),
 	}
 
@@ -122,6 +122,7 @@ var (
 				scopeUserUpdate,
 				scopeBillingRead,
 			),
+			&v2.SkipGrants{},
 		),
 	}
 )

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -1,0 +1,127 @@
+package connector
+
+import (
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+)
+
+// Zoom API granular scopes referenced by the resource type capability annotations.
+// Server-to-Server OAuth apps created today must use granular scopes; the classic
+// `user:read:admin` / `user:write:admin` are no longer accepted.
+//
+// Note: Zoom splits user writes into distinct granular scopes —
+// `user:write:user:admin` only authorizes POST /v2/users (create);
+// PATCH /v2/users/{userId} (used for license tier updates) requires
+// the separate `user:update:user:admin` scope.
+const (
+	scopeUserReadList = "user:read:list_users:admin"
+	scopeUserRead     = "user:read:user:admin"
+	scopeUserWrite    = "user:write:user:admin"
+	scopeUserUpdate   = "user:update:user:admin"
+	scopeUserDelete   = "user:delete:user:admin"
+	scopeBillingRead  = "billing:read:plan_usage:admin"
+)
+
+func capabilityPermissions(perms ...string) *v2.CapabilityPermissions {
+	cp := &v2.CapabilityPermissions{}
+	for _, p := range perms {
+		cp.Permissions = append(cp.Permissions, &v2.CapabilityPermission{Permission: p})
+	}
+	return cp
+}
+
+var (
+	resourceTypeUser = &v2.ResourceType{
+		Id:          "user",
+		DisplayName: "User",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_USER,
+		},
+		Annotations: annotations.New(
+			capabilityPermissions(
+				scopeUserRead,
+				scopeUserReadList,
+				scopeUserWrite,
+				scopeUserDelete,
+			),
+			&v2.SkipEntitlementsAndGrants{},
+		),
+	}
+
+	resourceTypeGroup = &v2.ResourceType{
+		Id:          "group",
+		DisplayName: "Group",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_GROUP,
+		},
+		Annotations: annotations.New(
+			capabilityPermissions(
+				"group:read:list_groups:admin",
+				"group:read:list_members:admin",
+				"group:read:administrator:admin",
+				"group:write:member:admin",
+				"group:delete:member:admin",
+				"group:write:administrator:admin",
+				"group:delete:administrator:admin",
+			),
+		),
+	}
+
+	resourceTypeContactGroup = &v2.ResourceType{
+		Id:          "contactGroup",
+		DisplayName: "Contact Group",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_GROUP,
+		},
+		Annotations: annotations.New(
+			capabilityPermissions(
+				"contact_group:read:list_groups:admin",
+				"contact_group:read:list_members:admin",
+			),
+		),
+	}
+
+	resourceTypeInvite = &v2.ResourceType{
+		Id:          "invite",
+		DisplayName: "Invite",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_USER,
+		},
+		Annotations: annotations.New(
+			capabilityPermissions(scopeUserReadList),
+			&v2.SkipEntitlementsAndGrants{},
+		),
+	}
+
+	resourceTypeRole = &v2.ResourceType{
+		Id:          "role",
+		DisplayName: "Role",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_ROLE,
+		},
+		Annotations: annotations.New(
+			capabilityPermissions(
+				"role:read:list_roles:admin",
+				"role:read:list_members:admin",
+				"role:write:member:admin",
+				"role:delete:member:admin",
+			),
+		),
+	}
+
+	resourceTypeLicense = &v2.ResourceType{
+		Id:          "license",
+		DisplayName: "License",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_LICENSE_PROFILE,
+		},
+		Annotations: annotations.New(
+			capabilityPermissions(
+				scopeUserReadList,
+				scopeUserRead,
+				scopeUserUpdate,
+				scopeBillingRead,
+			),
+		),
+	}
+)

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -185,7 +185,7 @@ func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotat
 	principal := grant.Principal
 
 	if principal.Id.ResourceType != resourceTypeUser.Id {
-		l.Warn(
+		l.Debug(
 			"baton-zoom: only users can have role membership revoked",
 			zap.String("principal_type", principal.Id.ResourceType),
 			zap.String("principal_id", principal.Id.Resource),

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -30,7 +30,7 @@ func (r *roleResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 
 // Create a new connector resource for a Zoom role.
 func roleResource(role zoom.Role, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
-	profile := map[string]interface{}{
+	profile := map[string]any{
 		"role_name": role.Name,
 		"role_id":   role.ID,
 	}

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -24,7 +24,7 @@ func (u *userResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 
 // Create a new connector resource for a Zoom user.
 func userResource(user zoom.User, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
-	profile := map[string]interface{}{
+	profile := map[string]any{
 		firstNameKey: user.FirstName,
 		lastNameKey:  user.LastName,
 		"login":      user.Email,
@@ -36,7 +36,7 @@ func userResource(user zoom.User, parentResourceID *v2.ResourceId) (*v2.Resource
 	switch user.Status {
 	case userStatusInactive:
 		userStatus = v2.UserTrait_Status_STATUS_DISABLED
-	case "active":
+	case userStatusActive:
 		userStatus = v2.UserTrait_Status_STATUS_ENABLED
 	default:
 		userStatus = v2.UserTrait_Status_STATUS_UNSPECIFIED
@@ -78,7 +78,7 @@ func (u *userResourceType) List(ctx context.Context, parentId *v2.ResourceId, op
 		if u.syncInactiveUsers {
 			b.Push(pagination.PageState{ResourceTypeID: resourceTypeUser.Id, ResourceID: userStatusInactive})
 		}
-		b.Push(pagination.PageState{ResourceTypeID: resourceTypeUser.Id, ResourceID: "active"})
+		b.Push(pagination.PageState{ResourceTypeID: resourceTypeUser.Id, ResourceID: userStatusActive})
 	}
 
 	status := b.Current().ResourceID

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -3,13 +3,22 @@ package connector
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-zoom/pkg/zoom"
+)
+
+const (
+	// userTypeProfileKey carries the user's Zoom license tier (User.type) on
+	// the user resource profile so userBuilder.Grants can emit the
+	// principal-side license grant without an extra GET /v2/users/{id} call.
+	userTypeProfileKey = "type"
 )
 
 type userResourceType struct {
@@ -25,10 +34,11 @@ func (u *userResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 // Create a new connector resource for a Zoom user.
 func userResource(user zoom.User, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
 	profile := map[string]any{
-		firstNameKey: user.FirstName,
-		lastNameKey:  user.LastName,
-		"login":      user.Email,
-		"user_id":    user.ID,
+		firstNameKey:       user.FirstName,
+		lastNameKey:        user.LastName,
+		"login":            user.Email,
+		"user_id":          user.ID,
+		userTypeProfileKey: int64(user.Type),
 	}
 
 	var userStatus v2.UserTrait_Status_Status
@@ -125,8 +135,65 @@ func (u *userResourceType) Entitlements(_ context.Context, _ *v2.Resource, _ res
 	return nil, &resource.SyncOpResults{}, nil
 }
 
-func (u *userResourceType) Grants(_ context.Context, _ *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
-	return nil, &resource.SyncOpResults{}, nil
+// Grants emits the principal-side license grant for a single user resource.
+// License is a derived resource type (no /licenses endpoint in Zoom), so its
+// grants are produced from the user side using the User.type value stashed in
+// the resource profile during List(). NoneUser (99) and unknown enum values
+// yield no grant — the matching License resource was never listed, so
+// emitting one would dangle.
+func (u *userResourceType) Grants(_ context.Context, res *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
+	userTrait, err := resource.GetUserTrait(res)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-zoom: failed to read user trait while emitting license grant: %w", err)
+	}
+
+	profile := userTrait.GetProfile().AsMap()
+	rawType, ok := profile[userTypeProfileKey]
+	if !ok {
+		return nil, &resource.SyncOpResults{}, nil
+	}
+
+	// structpb decodes JSON numbers as float64; the int / int64 branches
+	// cover the unlikely path where the profile is constructed in-process
+	// without going through a JSON round-trip.
+	var userType int
+	switch v := rawType.(type) {
+	case float64:
+		userType = int(v)
+	case int:
+		userType = v
+	case int64:
+		userType = int(v)
+	default:
+		return nil, &resource.SyncOpResults{}, nil
+	}
+
+	if !isLicenseTier(zoom.UserType(userType)) {
+		return nil, &resource.SyncOpResults{}, nil
+	}
+
+	licenseResource := &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: resourceTypeLicense.Id,
+			Resource:     strconv.Itoa(userType),
+		},
+	}
+
+	return []*v2.Grant{
+		grant.NewGrant(licenseResource, assignedEntitlement, res.Id),
+	}, &resource.SyncOpResults{}, nil
+}
+
+// isLicenseTier reports whether the given Zoom user type maps to a License
+// resource we sync. Basic / Licensed / On-Prem are tiers; NoneUser (99) is
+// "no license" and any unknown value is treated as such.
+func isLicenseTier(t zoom.UserType) bool {
+	switch t {
+	case zoom.BasicUser, zoom.LicensedUser, zoom.OnPremUser:
+		return true
+	default:
+		return false
+	}
 }
 
 func (u *userResourceType) CreateAccountCapabilityDetails(_ context.Context) (*v2.CredentialDetailsAccountProvisioning, annotations.Annotations, error) {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -138,7 +138,7 @@ func (u *userResourceType) Entitlements(_ context.Context, _ *v2.Resource, _ res
 // Grants emits the principal-side license grant for a single user resource.
 // License is a derived resource type (no /licenses endpoint in Zoom), so its
 // grants are produced from the user side using the User.type value stashed in
-// the resource profile during List(). NoneUser (99) and unknown enum values
+// the resource profile during List(). Values outside the modeled tiers
 // yield no grant — the matching License resource was never listed, so
 // emitting one would dangle.
 func (u *userResourceType) Grants(_ context.Context, res *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
@@ -185,11 +185,11 @@ func (u *userResourceType) Grants(_ context.Context, res *v2.Resource, _ resourc
 }
 
 // isLicenseTier reports whether the given Zoom user type maps to a License
-// resource we sync. Basic / Licensed / On-Prem are tiers; NoneUser (99) is
-// "no license" and any unknown value is treated as such.
+// resource we sync. Basic / Licensed / Unassigned are the modeled tiers;
+// any other value is treated as "no license".
 func isLicenseTier(t zoom.UserType) bool {
 	switch t {
-	case zoom.BasicUser, zoom.LicensedUser, zoom.OnPremUser:
+	case zoom.BasicUser, zoom.LicensedUser, zoom.UnassignedUser:
 		return true
 	default:
 		return false

--- a/pkg/zoom/client.go
+++ b/pkg/zoom/client.go
@@ -268,7 +268,7 @@ func (c *Client) AddGroupMembers(ctx context.Context, groupId, userId string) er
 		},
 	}
 
-	requestBody, err := json.Marshal(map[string]interface{}{
+	requestBody, err := json.Marshal(map[string]any{
 		"members": members,
 	})
 	if err != nil {
@@ -297,7 +297,7 @@ func (c *Client) AddGroupAdmins(ctx context.Context, groupId, userId string) err
 		},
 	}
 
-	requestBody, err := json.Marshal(map[string]interface{}{
+	requestBody, err := json.Marshal(map[string]any{
 		"admins": members,
 	})
 	if err != nil {
@@ -354,7 +354,7 @@ func (c *Client) AssignRole(ctx context.Context, roleId, userId string) error {
 		},
 	}
 
-	requestBody, err := json.Marshal(map[string]interface{}{
+	requestBody, err := json.Marshal(map[string]any{
 		"members": members,
 	})
 
@@ -423,6 +423,44 @@ func (c *Client) DeleteUser(ctx context.Context, userId string) error {
 
 	defer resp.Body.Close()
 	return nil
+}
+
+// PatchUserLicense updates a user's license tier via PATCH /v2/users/{userId}.
+// Zoom returns 204 No Content on success and applies any seat consumption or
+// release immediately.
+func (c *Client) PatchUserLicense(ctx context.Context, userId string, licenseType UserType) error {
+	requestURL, err := url.JoinPath(c.baseURL, "users", userId)
+	if err != nil {
+		return err
+	}
+
+	requestBody, err := json.Marshal(UserPatchBody{Type: licenseType})
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.doRequest(ctx, requestURL, nil, http.MethodPatch, nil, requestBody)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	return nil
+}
+
+// GetAccountPlanUsage returns the base plan's purchased and consumed seat
+// counts from GET /v2/accounts/me/plans/usage. Requires the
+// `billing:read:plan_usage:admin` scope (or the legacy `billing:read`).
+func (c *Client) GetAccountPlanUsage(ctx context.Context) (*PlanUsage, *http.Response, error) {
+	requestURL := fmt.Sprint(c.baseURL, "/accounts/me/plans/usage")
+	var res PlanUsage
+
+	response, err := c.doRequest(ctx, requestURL, &res, http.MethodGet, nil, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &res, response, nil
 }
 
 func (c *Client) doRequest(ctx context.Context, url string, res interface{}, method string, params url.Values, payload []byte) (*http.Response, error) {

--- a/pkg/zoom/models.go
+++ b/pkg/zoom/models.go
@@ -10,11 +10,12 @@ const (
 	SSOCreate      ActionType = "ssoCreate"
 
 	// Zoom user license tiers exposed by the `type` field on GET /v2/users.
-	// Source: https://developers.zoom.us/docs/api/users/
-	BasicUser    UserType = 1
-	LicensedUser UserType = 2
-	OnPremUser   UserType = 3
-	NoneUser     UserType = 99
+	// The API enum is 1, 2, 4, 99; type=99 (None) is settable only via the
+	// ssoCreate action (never via PATCH), so only the PATCH-assignable tiers
+	// are modeled here. Source: https://developers.zoom.us/docs/api/users/
+	BasicUser      UserType = 1
+	LicensedUser   UserType = 2
+	UnassignedUser UserType = 4 // "Unassigned without Meetings Basic" (aka No Meetings License)
 )
 
 type Group struct {

--- a/pkg/zoom/models.go
+++ b/pkg/zoom/models.go
@@ -9,10 +9,12 @@ const (
 	CustCreateUser ActionType = "custCreate"
 	SSOCreate      ActionType = "ssoCreate"
 
-	BasicUser      UserType = 1
-	LicensedUser   UserType = 2
-	UnnasignedUser UserType = 3
-	NoneUser       UserType = 99
+	// Zoom user license tiers exposed by the `type` field on GET /v2/users.
+	// Source: https://developers.zoom.us/docs/api/users/
+	BasicUser    UserType = 1
+	LicensedUser UserType = 2
+	OnPremUser   UserType = 3
+	NoneUser     UserType = 99
 )
 
 type Group struct {
@@ -97,4 +99,28 @@ type GroupMember struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 	Type int    `json:"type"`
+}
+
+// PlanBase describes the base plan slot from GET /v2/accounts/me/plans/usage.
+// Hosts is the number of purchased Licensed seats; Usage is the number of
+// consumed Licensed seats. Pending is the count queued by an admin but not
+// yet applied.
+type PlanBase struct {
+	Type    string `json:"type"`
+	Hosts   int    `json:"hosts"`
+	Usage   int    `json:"usage"`
+	Pending int    `json:"pending"`
+}
+
+// PlanUsage is the minimal projection of the plan usage payload that this
+// connector consumes. Zoom returns many additional fields (recording, room,
+// webinar, etc.) that we deliberately ignore.
+type PlanUsage struct {
+	PlanBase PlanBase `json:"plan_base"`
+}
+
+// UserPatchBody is the body sent to PATCH /v2/users/{userId} when changing a
+// user's license tier. A 204 No Content response indicates success.
+type UserPatchBody struct {
+	Type UserType `json:"type"`
 }


### PR DESCRIPTION
## Description

- [ ] Bug fix
- [x] New feature

Adds a `license` resource type that models Zoom's three license tiers (Basic, Licensed, On-Prem) as static resources, with user grants emitted principal-side from `userBuilder.Grants` and seat counts surfaced via `LicenseProfileTrait` for the C1 App Utilization feature (CE-720).

Closes [CXH-1571](https://linear.app/ductone/issue/CXH-1571/baton-zoom-add-license-management).

## Implementation

- License resources are static (no `/licenses` endpoint in Zoom) — tiers are fixed integer codes on `User.type`: Basic (1), Licensed (2), On-Prem (3).
- License is a **derived** resource type: grants are emitted from `userBuilder.Grants` (principal-side) using `User.type` stashed in the user resource profile during `List()`. `licenseResourceType.Grants` is a no-op. This keeps sync at `O(users)` instead of `O(users × tiers)`.
- Grant / Revoke: `PATCH /v2/users/{userId}` with `{"type": N}`. Revoke downgrades to Basic (Zoom has no "no license" state — Basic is the floor tier).
- Idempotency uses a **triple short-circuit**, each backed by a single pre-flight `GetUser` (no extra `PATCH`):
  - Grant of the user's current tier → `GrantAlreadyExists`
  - Revoke of a tier the user no longer holds → `GrantAlreadyRevoked`
  - Revoke of the floor tier (Basic) → `GrantAlreadyRevoked`
- `LicenseProfileTrait` is wired on every tier (`LicenseName` + `EntitlementIDs` = `license:<id>:assigned` so App Utilization can correlate `consumed_seats` to user grants). Seat counts (`WithLicenseSeats`) are added **only on Licensed** when `purchased > 0` — Basic is uncapped (Zoom doesn't track it) and On-Prem is provisioned outside Zoom Cloud (no billing-API visibility).
- Seat counts come from `GET /v2/accounts/me/plans/usage` (`plan_base.hosts` / `plan_base.usage`) — best-effort: if the billing scope is missing or the call fails, the three tiers still emit, just without seat numbers on Licensed.
- The full reasoning (how Zoom licensing maps onto C1, why tiers are static, what's deliberately out of scope) lives in the header comment of `pkg/connector/license.go:1-72`.

## Scopes required

Granular Server-to-Server OAuth scopes:

- `user:update:user:admin` — `PATCH /v2/users/{userId}` (required for Grant/Revoke).
- `billing:read:plan_usage:admin` — `GET /v2/accounts/me/plans/usage` (optional; enables seat-count enrichment on Licensed).

## Validation

End-to-end against a live Business-Monthly tenant: sync, Grant, idempotent re-Grant, Revoke, idempotent re-Revoke (non-held tier and floor tier), and license assignment from the C1 platform UI after email-invitation acceptance. `plan_base.usage` matches `count(User.type == 2)` on every state transition.

## Useful links

- [Zoom — Update a user](https://developers.zoom.us/docs/api/users/#tag/users/patch/users/{userId})
- [Zoom — Get plan usage](https://developers.zoom.us/docs/api/users/#tag/users/post/users/features)
- [baton-microsoft-entra/pkg/connector/licenses.go](https://github.com/ConductorOne/baton-microsoft-entra/blob/main/pkg/connector/licenses.go) (reference implementation)
- [Zoom Postman workspace](https://www.postman.com/zoom-developer/zoom-public-workspace)