### PR TITLE
feat: mark invite resource type as skipSyncAnomalyDetection

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -120,6 +120,9 @@
           },
           {
             "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+          },
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipSyncAnomalyDetection"
           }
         ]
       },
@@ -132,7 +135,8 @@
             "permission": "user:read:list_users:admin"
           }
         ]
-      }
+      },
+      "skipSyncAnomalyDetection": true
     },
     {
       "resourceType": {

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -21,6 +21,8 @@ This connector works with Zoom on the Pro, Business, Business Plus, or Enterpris
 | Contact groups | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |                                                               |
 | Invites        | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |                                                               |
 
+Invites represent pending Zoom user invitations and are transient — they disappear once the invitee accepts. C1 syncs invites for visibility but skips sync anomaly detection on them, since their counts naturally fluctuate.
+
 The Zoom connector supports [automatic account provisioning](/product/admin/account-provisioning).
 
 The Zoom connector supports account deprovisioning (user deletion).

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -90,6 +90,7 @@ var (
 		Annotations: annotations.New(
 			capabilityPermissions(scopeUserReadList),
 			&v2.SkipEntitlementsAndGrants{},
+			&v2.SkipSyncAnomalyDetection{},
 		),
 	}
 


### PR DESCRIPTION
## Summary
Mark the `invite` resource type with the `SkipSyncAnomalyDetection` annotation. Counts on this type can legitimately drop between syncs as pending invitees accept and are reclassified as users. Without this annotation, sync anomaly detection would flag those expected drops.

The `user` resource type intentionally remains anomaly-checked.

## Test plan
- [x] `go build ./...`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
